### PR TITLE
refactor(vdb): centralize vector store access

### DIFF
--- a/src/agent/routes/delete.py
+++ b/src/agent/routes/delete.py
@@ -1,11 +1,9 @@
 """Route to handle the deletion of a vector from the database."""
 
 from fastapi import APIRouter
-from loguru import logger
-from qdrant_client import models
 from qdrant_client.http.models.models import UpdateResult
 
-from agent.utils.vdb import get_async_qdrant_client
+from agent.utils.vdb import delete_documents_by_source
 
 router = APIRouter()
 
@@ -24,17 +22,4 @@ async def delete(source: str, collection_name: str) -> UpdateResult:
         UpdateResult: Result of the Update.
 
     """
-    logger.info("Deleting Vector from Database")
-    qdrant_client = get_async_qdrant_client()
-    result = await qdrant_client.delete(
-        collection_name=collection_name,
-        points_selector=models.FilterSelector(
-            filter=models.Filter(
-                must=[
-                    models.FieldCondition(key="metadata.source", match=models.MatchValue(value=source)),
-                ],
-            )
-        ),
-    )
-    logger.info("Deleted Point from Database via Metadata.")
-    return result
+    return await delete_documents_by_source(collection_name=collection_name, source=source)

--- a/src/agent/utils/retriever.py
+++ b/src/agent/utils/retriever.py
@@ -2,11 +2,10 @@
 
 from langchain_core.embeddings import Embeddings
 from langchain_core.retrievers import BaseRetriever
-from langchain_qdrant import QdrantVectorStore, RetrievalMode
 
 from agent.utils.config import config
 from agent.utils.embeddings import get_embedding_model
-from agent.utils.vdb import qdrant_client, sparse_embeddings
+from agent.utils.vdb import get_vector_store
 
 # Cache embeddings - created once per model name
 _embeddings_cache: dict[tuple[str, str], Embeddings] = {}
@@ -18,24 +17,6 @@ def _get_cached_embedding() -> Embeddings:
     if key not in _embeddings_cache:
         _embeddings_cache[key] = get_embedding_model(config)
     return _embeddings_cache[key]
-
-
-# Cache vector stores per collection
-_vector_store_cache: dict[str, QdrantVectorStore] = {}
-
-
-def _get_cached_vector_store(collection_name: str) -> QdrantVectorStore:
-    """Get or create cached QdrantVectorStore for a collection."""
-    if collection_name not in _vector_store_cache:
-        _vector_store_cache[collection_name] = QdrantVectorStore(
-            client=qdrant_client,
-            collection_name=collection_name,
-            embedding=_get_cached_embedding(),
-            sparse_embedding=sparse_embeddings,
-            retrieval_mode=RetrievalMode.HYBRID,
-            sparse_vector_name="fast-sparse-bm25",
-        )
-    return _vector_store_cache[collection_name]
 
 
 def get_retriever(k: int = 4, collection_name: str = "default") -> BaseRetriever:
@@ -51,5 +32,5 @@ def get_retriever(k: int = 4, collection_name: str = "default") -> BaseRetriever
         BaseRetriever: Qdrant + Cohere Embeddings Retriever with hybrid search.
 
     """
-    vector_db = _get_cached_vector_store(collection_name)
+    vector_db = get_vector_store(collection_name=collection_name, embedding=_get_cached_embedding())
     return vector_db.as_retriever(search_kwargs={"k": k})

--- a/src/agent/utils/vdb.py
+++ b/src/agent/utils/vdb.py
@@ -6,16 +6,18 @@ from langchain_core.embeddings import Embeddings
 from langchain_qdrant import FastEmbedSparse, QdrantVectorStore, RetrievalMode
 from loguru import logger
 from qdrant_client import AsyncQdrantClient, QdrantClient, models
+from qdrant_client.http.models.models import UpdateResult
 
 from agent.utils.config import Config
 
-sparse_embeddings = FastEmbedSparse(model_name="Qdrant/bm25")
+_sparse_embeddings = FastEmbedSparse(model_name="Qdrant/bm25")
+_vector_store_cache: dict[str, QdrantVectorStore] = {}
 
 settings = Config()
 
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=UserWarning, message="Api key is used with an insecure connection")
-    qdrant_client = QdrantClient(
+    _qdrant_client = QdrantClient(
         location=settings.qdrant_url,
         port=settings.qdrant_port,
         api_key=settings.qdrant_api_key,
@@ -24,7 +26,7 @@ with warnings.catch_warnings():
 
 with warnings.catch_warnings():
     warnings.filterwarnings("ignore", category=UserWarning, message="Api key is used with an insecure connection")
-    async_qdrant_client = AsyncQdrantClient(
+    _async_qdrant_client = AsyncQdrantClient(
         location=settings.qdrant_url,
         port=settings.qdrant_port,
         api_key=settings.qdrant_api_key,
@@ -48,10 +50,10 @@ def init_vdb(collection_name: str, embedding: Embeddings) -> QdrantVectorStore:
     logger.info(f"USING COLLECTION: {collection_name}")
 
     vector_db = QdrantVectorStore(
-        client=qdrant_client,
+        client=load_vec_db_conn(),
         collection_name=collection_name,
         embedding=embedding,
-        sparse_embedding=sparse_embeddings,
+        sparse_embedding=_sparse_embeddings,
         retrieval_mode=RetrievalMode.HYBRID,
         sparse_vector_name="fast-sparse-bm25",
     )
@@ -68,7 +70,7 @@ def load_vec_db_conn() -> QdrantClient:
         QdrantClient: The shared QdrantClient instance.
 
     """
-    return qdrant_client
+    return _qdrant_client
 
 
 def get_async_qdrant_client() -> AsyncQdrantClient:
@@ -79,7 +81,14 @@ def get_async_qdrant_client() -> AsyncQdrantClient:
         AsyncQdrantClient: The shared AsyncQdrantClient instance.
 
     """
-    return async_qdrant_client
+    return _async_qdrant_client
+
+
+def get_vector_store(collection_name: str, embedding: Embeddings) -> QdrantVectorStore:
+    """Return a cached hybrid vector store for a collection."""
+    if collection_name not in _vector_store_cache:
+        _vector_store_cache[collection_name] = init_vdb(collection_name=collection_name, embedding=embedding)
+    return _vector_store_cache[collection_name]
 
 
 def initialize_vector_db(collection_name: str, embeddings_size: int) -> None:
@@ -115,6 +124,21 @@ def generate_collection(collection_name: str, embeddings_size: int) -> None:
         sparse_vectors_config=client.get_fastembed_sparse_vector_params(),
     )
     logger.info(f"SUCCESS: Collection {collection_name} created.")
+
+
+async def delete_documents_by_source(collection_name: str, source: str) -> UpdateResult:
+    """Delete all documents with a matching source from a collection."""
+    client = get_async_qdrant_client()
+    return await client.delete(
+        collection_name=collection_name,
+        points_selector=models.FilterSelector(
+            filter=models.Filter(
+                must=[
+                    models.FieldCondition(key="metadata.source", match=models.MatchValue(value=source)),
+                ],
+            )
+        ),
+    )
 
 
 async def initialize_vector_db_async(collection_name: str, embeddings_size: int) -> None:

--- a/tests/unit_tests/test_search_delete.py
+++ b/tests/unit_tests/test_search_delete.py
@@ -30,34 +30,30 @@ def test_search_no_documents(mock_get_retriever, client) -> None:
     assert response.json() == snapshot({"message": "No documents found."})
 
 
-@patch("agent.routes.delete.get_async_qdrant_client")
-def test_delete_vector(mock_load_conn, client) -> None:
-    mock_client = AsyncMock()
+@patch("agent.routes.delete.delete_documents_by_source", new_callable=AsyncMock)
+def test_delete_vector(mock_delete, client) -> None:
     mock_result = UpdateResult(operation_id=0, status="completed")
-    mock_client.delete.return_value = mock_result
-    mock_load_conn.return_value = mock_client
+    mock_delete.return_value = mock_result
 
     response = client.delete("/embeddings/delete/test.pdf?collection_name=test_coll")
 
     assert response.status_code == 200
     assert response.json()["status"] == "completed"
-    mock_client.delete.assert_called_once()
+    mock_delete.assert_awaited_once_with(collection_name="test_coll", source="test.pdf")
 
 
-@patch("agent.utils.retriever.qdrant_client")
-@patch("agent.utils.retriever.sparse_embeddings")
-@patch("agent.utils.retriever.QdrantVectorStore")
+@patch("agent.utils.retriever.get_vector_store")
 @patch("agent.utils.retriever.get_embedding_model")
-def test_get_retriever(mock_get_embedding_model, mock_vector_store, _mock_sparse, _mock_client) -> None:
+def test_get_retriever(mock_get_embedding_model, mock_get_vector_store) -> None:
     mock_vstore_instance = MagicMock()
-    mock_vector_store.return_value = mock_vstore_instance
+    mock_get_vector_store.return_value = mock_vstore_instance
 
     retriever_module._embeddings_cache.clear()
-    retriever_module._vector_store_cache.clear()
-    mock_get_embedding_model.return_value = MagicMock()
+    mock_embedding = MagicMock()
+    mock_get_embedding_model.return_value = mock_embedding
 
     get_retriever(k=5, collection_name="my_coll")
 
     mock_get_embedding_model.assert_called_once()
-    mock_vector_store.assert_called_once()
+    mock_get_vector_store.assert_called_once_with(collection_name="my_coll", embedding=mock_embedding)
     mock_vstore_instance.as_retriever.assert_called_with(search_kwargs={"k": 5})

--- a/tests/unit_tests/test_vdb.py
+++ b/tests/unit_tests/test_vdb.py
@@ -1,7 +1,15 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
-from unittest.mock import MagicMock, patch
-from agent.utils.vdb import initialize_vector_db, generate_collection, init_vdb, initialize_all_vector_dbs
+
 from agent.utils.config import Config
+from agent.utils.vdb import (
+    delete_documents_by_source,
+    get_vector_store,
+    init_vdb,
+    initialize_all_vector_dbs,
+    initialize_vector_db,
+)
 
 @patch("agent.utils.vdb.load_vec_db_conn")
 def test_initialize_vector_db_exists(mock_load_conn):
@@ -29,7 +37,7 @@ def test_initialize_vector_db_not_exists(mock_load_conn):
 
 @patch("agent.utils.vdb.QdrantVectorStore")
 @patch("agent.utils.vdb.FastEmbedSparse")
-def test_init_vdb(mock_sparse, mock_vstore):
+def test_init_vdb(_mock_sparse, mock_vstore):
     mock_embedding = MagicMock()
 
     init_vdb("test_coll", mock_embedding)
@@ -38,6 +46,37 @@ def test_init_vdb(mock_sparse, mock_vstore):
     args, kwargs = mock_vstore.call_args
     assert kwargs["collection_name"] == "test_coll"
     assert kwargs["embedding"] == mock_embedding
+
+def test_get_vector_store_is_cached():
+    with patch("agent.utils.vdb.init_vdb") as mock_init_vdb:
+        import agent.utils.vdb as vdb
+
+        vdb._vector_store_cache.clear()
+        mock_store = MagicMock()
+        mock_init_vdb.return_value = mock_store
+        embedding = MagicMock()
+
+        assert get_vector_store("test_coll", embedding) is mock_store
+        assert get_vector_store("test_coll", embedding) is mock_store
+
+        mock_init_vdb.assert_called_once_with(collection_name="test_coll", embedding=embedding)
+
+
+@pytest.mark.anyio
+@patch("agent.utils.vdb.get_async_qdrant_client")
+async def test_delete_documents_by_source(mock_get_client):
+    mock_client = AsyncMock()
+    mock_get_client.return_value = mock_client
+
+    await delete_documents_by_source(collection_name="test_coll", source="test.pdf")
+
+    mock_client.delete.assert_awaited_once()
+    call = mock_client.delete.call_args.kwargs
+    assert call["collection_name"] == "test_coll"
+    condition = call["points_selector"].filter.must[0]
+    assert condition.key == "metadata.source"
+    assert condition.match.value == "test.pdf"
+
 
 @patch("agent.utils.vdb.initialize_vector_db")
 def test_initialize_all_vector_dbs(mock_init_vdb):


### PR DESCRIPTION
## Summary
- centralize hybrid vector-store construction and collection caching in `agent.utils.vdb`
- hide Qdrant client, sparse embedding, and vector-store globals from retrieval
- move source-based deletion into the vector-store module
- update tests to exercise the storage seam instead of vendor globals

## Verification
- `PYTHONPATH=. uv run pytest -q -m "not vcr and not e2e" tests/` — 56 passed, 4 deselected
- `prek run --files src/agent/utils/vdb.py src/agent/utils/retriever.py src/agent/routes/delete.py tests/unit_tests/test_vdb.py tests/unit_tests/test_search_delete.py`
