### PR TITLE
fix(vdb): manage Qdrant resources with FastAPI lifespan

### DIFF
--- a/src/agent/api.py
+++ b/src/agent/api.py
@@ -1,5 +1,8 @@
 """Main API."""
 
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
 import pyfiglet
 from dotenv import load_dotenv
 from fastapi import FastAPI, Request
@@ -9,28 +12,42 @@ from loguru import logger
 from openinference.instrumentation.langchain import LangChainInstrumentor
 from phoenix.otel import register
 
+from agent.backend.graph import Graph
 from agent.routes import collection, delete, embeddings, rag, search
 from agent.utils.config import Config
-from agent.utils.vdb import initialize_all_vector_dbs
-
-load_dotenv(override=True)
-config = Config()
+from agent.utils.vdb import create_vdb_resources, initialize_all_vector_dbs
 
 
-initialize_all_vector_dbs(config=config)
-logger.info("Startup.")
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    """Own application resources from startup through shutdown."""
+    load_dotenv(override=True)
+    config = Config()
+    resources = create_vdb_resources(config)
+    app.state.vdb_resources = resources
 
-# configure the Phoenix tracer
-tracer_provider = register(
-    project_name="rag",
-    endpoint=config.phoenix_collector_endpoint,
-)
+    try:
+        await initialize_all_vector_dbs(config=config, client=resources.async_client)
+        app.state.graph = Graph(config=config).build_graph()
 
-LangChainInstrumentor().instrument(tracer_provider=tracer_provider)
+        tracer_provider = register(
+            project_name="rag",
+            endpoint=config.phoenix_collector_endpoint,
+        )
+        LangChainInstrumentor().instrument(tracer_provider=tracer_provider)
 
-# Show startup message
-f = pyfiglet.figlet_format("Conv Agent", font="alligator")
-logger.info(f"Welcome to\n\n{f}\n\n")
+        logger.info("Startup.")
+        startup_message = pyfiglet.figlet_format("Conv Agent", font="alligator")
+        logger.info(f"Welcome to\n\n{startup_message}\n\n")
+        yield
+    finally:
+        try:
+            resources.sync_client.close()
+        finally:
+            await resources.async_client.close()
+
+
+app = FastAPI(lifespan=lifespan)
 
 
 def my_schema() -> dict:
@@ -45,7 +62,6 @@ def my_schema() -> dict:
     return app.openapi_schema
 
 
-app = FastAPI()
 app.openapi = my_schema
 
 

--- a/src/agent/backend/graph.py
+++ b/src/agent/backend/graph.py
@@ -6,6 +6,7 @@ from typing import Literal
 from langchain_cohere import ChatCohere
 from langchain_litellm import ChatLiteLLM
 from langgraph.graph import END, StateGraph
+from langgraph.graph.state import CompiledStateGraph
 
 from agent.backend.nodes.generation import generate_response_cohere, generate_response_default
 from agent.backend.nodes.grading import grade_documents
@@ -19,15 +20,12 @@ GEMINI_MODEL_KEY = "gemini"
 COHERE_MODEL_KEY = "cohere_command"
 
 
-settings = Config()
-
-
 class Graph:
     """The LangGraph Graph."""
 
-    def __init__(self) -> None:
+    def __init__(self, config: Config | None = None) -> None:
         """Initialize the Graph."""
-        self.cfg = settings
+        self.cfg = config or Config()
 
         # define models
         self.llm = ChatLiteLLM(model_name=self.cfg.model_name, streaming=True)
@@ -58,7 +56,7 @@ class Graph:
         else:
             return "retriever_with_chat_history"
 
-    def build_graph(self) -> StateGraph:
+    def build_graph(self) -> CompiledStateGraph:
         """Build the graph for the agent."""
         workflow = StateGraph(state_schema=AgentState)
 

--- a/src/agent/backend/nodes/retrieval.py
+++ b/src/agent/backend/nodes/retrieval.py
@@ -13,6 +13,7 @@ from agent.backend.prompts import REPHRASE_TEMPLATE
 from agent.backend.state import AgentState
 from agent.utils.config import Config
 from agent.utils.retriever import get_retriever
+from agent.utils.vdb import VDBResources
 
 
 def get_chat_history(messages: Sequence[BaseMessage]) -> list:
@@ -24,13 +25,26 @@ def get_chat_history(messages: Sequence[BaseMessage]) -> list:
     ]
 
 
+def _get_vdb_resources(config: RunnableConfig) -> VDBResources:
+    """Read explicitly propagated VDB resources from the runnable config."""
+    resources = config.get("configurable", {}).get("vdb_resources")
+    if not isinstance(resources, VDBResources):
+        msg = "VDB resources are required in RunnableConfig.configurable"
+        raise TypeError(msg)
+    return resources
+
+
 def retrieve_documents(state: AgentState, config: RunnableConfig, *, cfg: Config) -> AgentState:
     """Retrieve documents from the retriever."""
     # Dynamic k: Increase k if retrying
     retry_count = state.get("retry_count", 0)
     k = cfg.retrieval_k if retry_count == 0 else cfg.retrieval_k_retry
 
-    retriever = get_retriever(k=k, collection_name=config["metadata"]["collection_name"])
+    retriever = get_retriever(
+        resources=_get_vdb_resources(config),
+        k=k,
+        collection_name=config["metadata"]["collection_name"],
+    )
     messages = convert_to_messages(messages=state["messages"])
     # If query was rewritten, use state["query"], otherwise use last message
     query = state.get("query") or messages[-1].content
@@ -48,7 +62,11 @@ def retrieve_documents_with_chat_history(state: AgentState, config: RunnableConf
     retry_count = state.get("retry_count", 0)
     k = cfg.retrieval_k if retry_count == 0 else cfg.retrieval_k_retry
 
-    retriever = get_retriever(k=k, collection_name=config["metadata"]["collection_name"])
+    retriever = get_retriever(
+        resources=_get_vdb_resources(config),
+        k=k,
+        collection_name=config["metadata"]["collection_name"],
+    )
     model = llm.with_config(tags=["nostream"])
 
     condense_queston_prompt = PromptTemplate.from_template(REPHRASE_TEMPLATE)

--- a/src/agent/backend/services/embedding_management.py
+++ b/src/agent/backend/services/embedding_management.py
@@ -5,9 +5,8 @@ from langchain_community.document_loaders import DirectoryLoader, PyPDFium2Loade
 from langchain_text_splitters import RecursiveCharacterTextSplitter
 from loguru import logger
 
-from agent.utils.config import config
 from agent.utils.embeddings import get_embedding_model
-from agent.utils.vdb import generate_collection, init_vdb
+from agent.utils.vdb import VDBResources, generate_collection, init_vdb
 
 load_dotenv()
 
@@ -15,16 +14,19 @@ load_dotenv()
 class EmbeddingManagement:
     """Wrapper for cohere llms."""
 
-    def __init__(self, collection_name: str | None) -> None:
-        """Init the Litellm Service."""
-        self.cfg = config
-
-        if collection_name:
-            self.collection_name = collection_name
+    def __init__(self, collection_name: str, resources: VDBResources) -> None:
+        """Initialize the embedding service with explicit VDB resources."""
+        self.cfg = resources.config
+        self.resources = resources
+        self.collection_name = collection_name
 
         embedding = get_embedding_model(self.cfg)
 
-        self.vector_db = init_vdb(collection_name=self.collection_name, embedding=embedding)
+        self.vector_db = init_vdb(
+            resources=self.resources,
+            collection_name=self.collection_name,
+            embedding=embedding,
+        )
 
     def embed_documents(self, directory: str, file_ending: str = ".pdf") -> None:
         """Embeds the documents in the given directory.
@@ -63,13 +65,23 @@ class EmbeddingManagement:
 
     def create_collection(self, name: str) -> bool:
         """Create a new collection in the Vector Database."""
-        generate_collection(name, self.cfg.embedding_size)
+        generate_collection(
+            client=self.resources.sync_client,
+            collection_name=name,
+            embeddings_size=self.cfg.embedding_size,
+        )
         return True
 
 
 if __name__ == "__main__":
-    query = "Was ist Attention?"
+    import asyncio
 
-    cohere_service = EmbeddingManagement(collection_name="")
+    from agent.utils.config import Config
+    from agent.utils.vdb import create_vdb_resources
 
-    cohere_service.embed_documents(directory="tests/resources/")
+    resources = create_vdb_resources(Config())
+    try:
+        service = EmbeddingManagement(collection_name="default", resources=resources)
+        service.embed_documents(directory="tests/resources/")
+    finally:
+        asyncio.run(resources.close())

--- a/src/agent/dependencies.py
+++ b/src/agent/dependencies.py
@@ -1,0 +1,22 @@
+"""Typed FastAPI dependencies for application-owned resources."""
+
+from typing import Annotated, cast
+
+from fastapi import Depends, Request
+from langgraph.graph.state import CompiledStateGraph
+
+from agent.utils.vdb import VDBResources
+
+
+def get_vdb_resources(request: Request) -> VDBResources:
+    """Return the process-scoped vector database resources."""
+    return cast("VDBResources", request.app.state.vdb_resources)
+
+
+def get_graph(request: Request) -> CompiledStateGraph:
+    """Return the process-scoped compiled RAG graph."""
+    return cast("CompiledStateGraph", request.app.state.graph)
+
+
+VDBResourcesDep = Annotated[VDBResources, Depends(get_vdb_resources)]
+GraphDep = Annotated[CompiledStateGraph, Depends(get_graph)]

--- a/src/agent/routes/collection.py
+++ b/src/agent/routes/collection.py
@@ -5,24 +5,34 @@ from typing import Annotated
 from fastapi import APIRouter, Query
 from fastapi.responses import JSONResponse
 
+from agent.dependencies import VDBResourcesDep
 from agent.utils.vdb import initialize_vector_db_async
 
 router = APIRouter()
 
 
 @router.post(path="/create/{collection_name}", tags=["collection"])
-async def create_collection(collection_name: str, embeddings_size: Annotated[int, Query(gt=0, le=5000)]) -> JSONResponse:
+async def create_collection(
+    collection_name: str,
+    embeddings_size: Annotated[int, Query(gt=0, le=5000)],
+    resources: VDBResourcesDep,
+) -> JSONResponse:
     """Create a new collection.
 
     Args:
     ----
         collection_name (str): Name of the Qdrant Collection
         embeddings_size (int): The size of the embeddings.
+        resources (VDBResources): Application-owned vector database resources.
 
     Returns:
     -------
         JSONResponse: Success Message.
 
     """
-    await initialize_vector_db_async(collection_name=collection_name, embeddings_size=embeddings_size)
+    await initialize_vector_db_async(
+        client=resources.async_client,
+        collection_name=collection_name,
+        embeddings_size=embeddings_size,
+    )
     return JSONResponse(content={"message": f"Collection {collection_name} created."})

--- a/src/agent/routes/delete.py
+++ b/src/agent/routes/delete.py
@@ -3,23 +3,29 @@
 from fastapi import APIRouter
 from qdrant_client.http.models.models import UpdateResult
 
+from agent.dependencies import VDBResourcesDep
 from agent.utils.vdb import delete_documents_by_source
 
 router = APIRouter()
 
 
 @router.delete("/delete/{source}", tags=["embeddings"])
-async def delete(source: str, collection_name: str) -> UpdateResult:
+async def delete(source: str, collection_name: str, resources: VDBResourcesDep) -> UpdateResult:
     """Delete a vector from the database.
 
     Args:
     ----
         source (str): Name of the Document
         collection_name (str): Name of the Qdrant Collection.
+        resources (VDBResources): Application-owned vector database resources.
 
     Returns:
     -------
         UpdateResult: Result of the Update.
 
     """
-    return await delete_documents_by_source(collection_name=collection_name, source=source)
+    return await delete_documents_by_source(
+        client=resources.async_client,
+        collection_name=collection_name,
+        source=source,
+    )

--- a/src/agent/routes/embeddings.py
+++ b/src/agent/routes/embeddings.py
@@ -12,6 +12,7 @@ from werkzeug.utils import secure_filename
 from agent.backend.services.embedding_management import EmbeddingManagement
 from agent.data_model.request_data_model import EmbeddTextRequest
 from agent.data_model.response_data_model import EmbeddingResponse
+from agent.dependencies import VDBResourcesDep
 from agent.utils.utility import create_tmp_folder
 
 router = APIRouter()
@@ -40,6 +41,7 @@ async def _write_file_to_disk(file_path: Path, file_content: bytes) -> None:
 async def post_embed_documents(
     collection_name: str,
     files: Annotated[list[UploadFile], File(description="A list of files to be embedded.")],
+    resources: VDBResourcesDep,
     file_ending: str = ".pdf",
 ) -> EmbeddingResponse:
     """Endpoint concurrently processes and embeds multiple uploaded documents.
@@ -81,7 +83,7 @@ async def post_embed_documents(
         ) from e
 
     # Consider running this in a thread if it's a blocking CPU-bound operation
-    service = EmbeddingManagement(collection_name=collection_name)
+    service = EmbeddingManagement(collection_name=collection_name, resources=resources)
     try:
         # This part remains synchronous as per the original code.
         # If embed_documents is I/O bound, it should be made async.
@@ -104,10 +106,14 @@ async def _process_and_write_file(file: UploadFile, file_path: Path) -> None:
 
 
 @router.post("/string/", tags=["embeddings"])
-async def embedd_text(embedding: EmbeddTextRequest, collection_name: str) -> EmbeddingResponse:
+async def embedd_text(
+    embedding: EmbeddTextRequest,
+    collection_name: str,
+    resources: VDBResourcesDep,
+) -> EmbeddingResponse:
     """Embedding text."""
     logger.info("Embedding Text")
-    service = EmbeddingManagement(collection_name=collection_name)
+    service = EmbeddingManagement(collection_name=collection_name, resources=resources)
     tmp_dir = create_tmp_folder()
 
     sanitized_file_name = secure_filename(embedding.file_name + ".txt")

--- a/src/agent/routes/rag.py
+++ b/src/agent/routes/rag.py
@@ -5,31 +5,41 @@ from collections.abc import AsyncGenerator
 
 from fastapi import APIRouter
 from fastapi.responses import StreamingResponse
+from langchain_core.runnables import RunnableConfig  # noqa: TC002
 
-from agent.backend.graph import Graph
 from agent.data_model.request_data_model import RAGRequest
 from agent.data_model.response_data_model import QAResponse
-
-graph = Graph().build_graph()
-
+from agent.dependencies import GraphDep, VDBResourcesDep
 
 router = APIRouter()
 
 
 @router.post("/", tags=["rag"])
-async def question_answer(rag: RAGRequest) -> QAResponse:
+async def question_answer(rag: RAGRequest, graph: GraphDep, resources: VDBResourcesDep) -> QAResponse:
     """Answering the Question."""
     messages = [dict(m) for m in rag.messages]
-    chain_result = await graph.with_config({"metadata": {"collection_name": rag.collection_name}}).ainvoke({"messages": messages})
+    run_config: RunnableConfig = {
+        "metadata": {"collection_name": rag.collection_name},
+        "configurable": {"vdb_resources": resources},
+    }
+    chain_result = await graph.with_config(run_config).ainvoke({"messages": messages})
 
     documents = [{"document": [doc.page_content], "metadata": [doc.metadata]} for doc in chain_result["documents"]]
     return QAResponse(answer=chain_result["messages"][-1].content, meta_data=documents)
 
 
 @router.post("/stream", tags=["rag"])
-async def question_answer_stream(rag: RAGRequest) -> StreamingResponse:
+async def question_answer_stream(
+    rag: RAGRequest,
+    graph: GraphDep,
+    resources: VDBResourcesDep,
+) -> StreamingResponse:
     """Stream the Answering."""
     messages = [dict(m) for m in rag.messages]
+    run_config: RunnableConfig = {
+        "metadata": {"collection_name": rag.collection_name},
+        "configurable": {"vdb_resources": resources},
+    }
 
     async def stream() -> AsyncGenerator:
         documents = []
@@ -37,7 +47,7 @@ async def question_answer_stream(rag: RAGRequest) -> StreamingResponse:
         # Yield initial status
         yield json.dumps({"type": "status", "data": "Starting request..."}) + "\n"
 
-        async for chunk in graph.with_config({"metadata": {"collection_name": rag.collection_name}}).astream_events({"messages": messages}, version="v2"):
+        async for chunk in graph.with_config(run_config).astream_events({"messages": messages}, version="v2"):
             # Status updates for Retrieval
             if chunk["event"] == "on_chain_start" and chunk["name"] in ["retriever", "retriever_with_chat_history"]:
                 yield json.dumps({"type": "status", "data": "Searching documents..."}) + "\n"

--- a/src/agent/routes/search.py
+++ b/src/agent/routes/search.py
@@ -6,16 +6,18 @@ from loguru import logger
 
 from agent.data_model.request_data_model import SearchParams
 from agent.data_model.response_data_model import SearchResponse
+from agent.dependencies import VDBResourcesDep
 from agent.utils.retriever import get_retriever
 
 router = APIRouter()
 
 
 @router.post("/search", tags=["search"], response_model=list[SearchResponse])
-async def search(search: SearchParams) -> list[SearchResponse] | JSONResponse:
+async def search(search: SearchParams, resources: VDBResourcesDep) -> list[SearchResponse] | JSONResponse:
     """Search for documents."""
     logger.info("Searching for Documents")
     retriever = get_retriever(
+        resources=resources,
         collection_name=search.collection_name,
         k=search.k,
     )

--- a/src/agent/scripts/load_dummy_data.py
+++ b/src/agent/scripts/load_dummy_data.py
@@ -1,15 +1,20 @@
-"""Simple Upload script for test data."""
+"""Simple upload script for test data."""
+
+import asyncio
 
 from agent.backend.services.embedding_management import EmbeddingManagement
-
-# from agent.utils.vdb import generate_collection
+from agent.utils.config import Config
+from agent.utils.vdb import create_vdb_resources
 
 
 def main() -> None:
-    """Generating test collection and uploading data for testing."""
-    # generate_collection(collection_name="asdf", embeddings_size=1536)
-    vdb = EmbeddingManagement(collection_name="default")
-    vdb.embed_documents(directory="resources")
+    """Generate a test collection and upload data for testing."""
+    resources = create_vdb_resources(Config())
+    try:
+        service = EmbeddingManagement(collection_name="default", resources=resources)
+        service.embed_documents(directory="resources")
+    finally:
+        asyncio.run(resources.close())
 
 
 if __name__ == "__main__":

--- a/src/agent/utils/config.py
+++ b/src/agent/utils/config.py
@@ -38,6 +38,3 @@ class Config(BaseSettings):
     qdrant_prefer_grpc: bool = False
     phoenix_collector_endpoint: str = "http://phoenix:4318/v1/traces"
     qdrant_collection_name: str = "default"
-
-
-config = Config()

--- a/src/agent/utils/retriever.py
+++ b/src/agent/utils/retriever.py
@@ -1,36 +1,26 @@
-"""Retriever utils with cached embeddings and vector stores."""
+"""Retriever utilities using application-owned embeddings and vector stores."""
 
 from langchain_core.embeddings import Embeddings
 from langchain_core.retrievers import BaseRetriever
 
-from agent.utils.config import config
 from agent.utils.embeddings import get_embedding_model
-from agent.utils.vdb import get_vector_store
-
-# Cache embeddings - created once per model name
-_embeddings_cache: dict[tuple[str, str], Embeddings] = {}
+from agent.utils.vdb import VDBResources, get_vector_store
 
 
-def _get_cached_embedding() -> Embeddings:
+def _get_cached_embedding(resources: VDBResources) -> Embeddings:
     """Get or create cached embeddings for the configured provider."""
+    config = resources.config
     key = (config.embedding_provider, config.embedding_model_name)
-    if key not in _embeddings_cache:
-        _embeddings_cache[key] = get_embedding_model(config)
-    return _embeddings_cache[key]
+    if key not in resources.embeddings_cache:
+        resources.embeddings_cache[key] = get_embedding_model(config)
+    return resources.embeddings_cache[key]
 
 
-def get_retriever(k: int = 4, collection_name: str = "default") -> BaseRetriever:
-    """Create a Vector Database retriever with hybrid search.
-
-    Uses cached embeddings and vector stores for performance.
-
-    Args:
-        k: Number of documents to retrieve.
-        collection_name: Name of the collection to search.
-
-    Returns:
-        BaseRetriever: Qdrant + Cohere Embeddings Retriever with hybrid search.
-
-    """
-    vector_db = get_vector_store(collection_name=collection_name, embedding=_get_cached_embedding())
+def get_retriever(resources: VDBResources, k: int = 4, collection_name: str = "default") -> BaseRetriever:
+    """Create a Qdrant hybrid-search retriever."""
+    vector_db = get_vector_store(
+        resources=resources,
+        collection_name=collection_name,
+        embedding=_get_cached_embedding(resources),
+    )
     return vector_db.as_retriever(search_kwargs={"k": k})

--- a/src/agent/utils/vdb.py
+++ b/src/agent/utils/vdb.py
@@ -1,6 +1,7 @@
 """Vector Database Utilities."""
 
 import warnings
+from dataclasses import dataclass, field
 
 from langchain_core.embeddings import Embeddings
 from langchain_qdrant import FastEmbedSparse, QdrantVectorStore, RetrievalMode
@@ -10,50 +11,62 @@ from qdrant_client.http.models.models import UpdateResult
 
 from agent.utils.config import Config
 
-_sparse_embeddings = FastEmbedSparse(model_name="Qdrant/bm25")
-_vector_store_cache: dict[str, QdrantVectorStore] = {}
 
-settings = Config()
+@dataclass
+class VDBResources:
+    """Process-scoped vector database resources owned by the API lifespan."""
 
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=UserWarning, message="Api key is used with an insecure connection")
-    _qdrant_client = QdrantClient(
-        location=settings.qdrant_url,
-        port=settings.qdrant_port,
-        api_key=settings.qdrant_api_key,
-        prefer_grpc=settings.qdrant_prefer_grpc,
+    config: Config
+    sync_client: QdrantClient
+    async_client: AsyncQdrantClient
+    sparse_embeddings: FastEmbedSparse
+    vector_store_cache: dict[str, QdrantVectorStore] = field(default_factory=dict)
+    embeddings_cache: dict[tuple[str, str], Embeddings] = field(default_factory=dict)
+
+    async def close(self) -> None:
+        """Close both Qdrant clients."""
+        try:
+            self.sync_client.close()
+        finally:
+            await self.async_client.close()
+
+
+def create_vdb_resources(config: Config) -> VDBResources:
+    """Create the vector database resources for one application process."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=UserWarning, message="Api key is used with an insecure connection")
+        sync_client = QdrantClient(
+            location=config.qdrant_url,
+            port=config.qdrant_port,
+            api_key=config.qdrant_api_key,
+            prefer_grpc=config.qdrant_prefer_grpc,
+        )
+        async_client = AsyncQdrantClient(
+            location=config.qdrant_url,
+            port=config.qdrant_port,
+            api_key=config.qdrant_api_key,
+            prefer_grpc=config.qdrant_prefer_grpc,
+        )
+
+    return VDBResources(
+        config=config,
+        sync_client=sync_client,
+        async_client=async_client,
+        sparse_embeddings=FastEmbedSparse(model_name="Qdrant/bm25"),
     )
 
-with warnings.catch_warnings():
-    warnings.filterwarnings("ignore", category=UserWarning, message="Api key is used with an insecure connection")
-    _async_qdrant_client = AsyncQdrantClient(
-        location=settings.qdrant_url,
-        port=settings.qdrant_port,
-        api_key=settings.qdrant_api_key,
-        prefer_grpc=settings.qdrant_prefer_grpc,
-    )
 
-
-def init_vdb(collection_name: str, embedding: Embeddings) -> QdrantVectorStore:
-    """Establish a connection to the Qdrant DB.
-
-    Args:
-    ----
-        collection_name (str): name of the collection in the Qdrant DB.
-        embedding (Embeddings): Embedding Type.
-
-    Returns:
-    -------
-        Qdrant: Established Connection to the Vector DB including Embeddings.
-
-    """
+def init_vdb(resources: VDBResources, collection_name: str, embedding: Embeddings) -> QdrantVectorStore:
+    """Establish a connection to the Qdrant DB."""
     logger.info(f"USING COLLECTION: {collection_name}")
 
+    # QdrantVectorStore requires the synchronous client even when retrieval is
+    # initiated by an async route. Direct async Qdrant operations use async_client.
     vector_db = QdrantVectorStore(
-        client=load_vec_db_conn(),
+        client=resources.sync_client,
         collection_name=collection_name,
         embedding=embedding,
-        sparse_embedding=_sparse_embeddings,
+        sparse_embedding=resources.sparse_embeddings,
         retrieval_mode=RetrievalMode.HYBRID,
         sparse_vector_name="fast-sparse-bm25",
     )
@@ -62,61 +75,27 @@ def init_vdb(collection_name: str, embedding: Embeddings) -> QdrantVectorStore:
     return vector_db
 
 
-def load_vec_db_conn() -> QdrantClient:
-    """Return the module-level synchronous QdrantClient singleton.
-
-    Returns
-    -------
-        QdrantClient: The shared QdrantClient instance.
-
-    """
-    return _qdrant_client
-
-
-def get_async_qdrant_client() -> AsyncQdrantClient:
-    """Return the module-level asynchronous QdrantClient singleton.
-
-    Returns
-    -------
-        AsyncQdrantClient: The shared AsyncQdrantClient instance.
-
-    """
-    return _async_qdrant_client
-
-
-def get_vector_store(collection_name: str, embedding: Embeddings) -> QdrantVectorStore:
+def get_vector_store(resources: VDBResources, collection_name: str, embedding: Embeddings) -> QdrantVectorStore:
     """Return a cached hybrid vector store for a collection."""
-    if collection_name not in _vector_store_cache:
-        _vector_store_cache[collection_name] = init_vdb(collection_name=collection_name, embedding=embedding)
-    return _vector_store_cache[collection_name]
+    if collection_name not in resources.vector_store_cache:
+        resources.vector_store_cache[collection_name] = init_vdb(
+            resources=resources,
+            collection_name=collection_name,
+            embedding=embedding,
+        )
+    return resources.vector_store_cache[collection_name]
 
 
-def initialize_vector_db(collection_name: str, embeddings_size: int) -> None:
-    """Initializes the vector db for a given backend.
-
-    Args:
-    ----
-        collection_name (str): Name of the Collection
-        embeddings_size (int): Size of the Embeddings
-
-    """
-    client = load_vec_db_conn()
+def initialize_vector_db(client: QdrantClient, collection_name: str, embeddings_size: int) -> None:
+    """Initialize a collection using the synchronous Qdrant client."""
     if client.collection_exists(collection_name=collection_name):
         logger.info(f"SUCCESS: Collection {collection_name} already exists.")
     else:
-        generate_collection(collection_name=collection_name, embeddings_size=embeddings_size)
+        generate_collection(client=client, collection_name=collection_name, embeddings_size=embeddings_size)
 
 
-def generate_collection(collection_name: str, embeddings_size: int) -> None:
-    """Generate a collection for a given backend.
-
-    Args:
-    ----
-        collection_name (str): Name of the Collection
-        embeddings_size (int): Size of the Embeddings
-
-    """
-    client = load_vec_db_conn()
+def generate_collection(client: QdrantClient, collection_name: str, embeddings_size: int) -> None:
+    """Generate a collection using the synchronous Qdrant client."""
     client.set_sparse_model(embedding_model_name="Qdrant/bm25")
     client.create_collection(
         collection_name=collection_name,
@@ -126,9 +105,8 @@ def generate_collection(collection_name: str, embeddings_size: int) -> None:
     logger.info(f"SUCCESS: Collection {collection_name} created.")
 
 
-async def delete_documents_by_source(collection_name: str, source: str) -> UpdateResult:
+async def delete_documents_by_source(client: AsyncQdrantClient, collection_name: str, source: str) -> UpdateResult:
     """Delete all documents with a matching source from a collection."""
-    client = get_async_qdrant_client()
     return await client.delete(
         collection_name=collection_name,
         points_selector=models.FilterSelector(
@@ -141,32 +119,16 @@ async def delete_documents_by_source(collection_name: str, source: str) -> Updat
     )
 
 
-async def initialize_vector_db_async(collection_name: str, embeddings_size: int) -> None:
-    """Initializes the vector db for a given backend asynchronously.
-
-    Args:
-    ----
-        collection_name (str): Name of the Collection
-        embeddings_size (int): Size of the Embeddings
-
-    """
-    client = get_async_qdrant_client()
+async def initialize_vector_db_async(client: AsyncQdrantClient, collection_name: str, embeddings_size: int) -> None:
+    """Initialize a collection using the asynchronous Qdrant client."""
     if await client.collection_exists(collection_name=collection_name):
         logger.info(f"SUCCESS: Collection {collection_name} already exists.")
     else:
-        await generate_collection_async(collection_name=collection_name, embeddings_size=embeddings_size)
+        await generate_collection_async(client=client, collection_name=collection_name, embeddings_size=embeddings_size)
 
 
-async def generate_collection_async(collection_name: str, embeddings_size: int) -> None:
-    """Generate a collection for a given backend asynchronously.
-
-    Args:
-    ----
-        collection_name (str): Name of the Collection
-        embeddings_size (int): Size of the Embeddings
-
-    """
-    client = get_async_qdrant_client()
+async def generate_collection_async(client: AsyncQdrantClient, collection_name: str, embeddings_size: int) -> None:
+    """Generate a collection using the asynchronous Qdrant client."""
     client.set_sparse_model(embedding_model_name="Qdrant/bm25")
     await client.create_collection(
         collection_name=collection_name,
@@ -176,6 +138,10 @@ async def generate_collection_async(collection_name: str, embeddings_size: int) 
     logger.info(f"SUCCESS: Collection {collection_name} created.")
 
 
-def initialize_all_vector_dbs(config: Config) -> None:
-    """Initializes all vector dbs."""
-    initialize_vector_db(collection_name=config.qdrant_collection_name, embeddings_size=config.embedding_size)
+async def initialize_all_vector_dbs(config: Config, client: AsyncQdrantClient) -> None:
+    """Initialize all configured vector databases asynchronously."""
+    await initialize_vector_db_async(
+        client=client,
+        collection_name=config.qdrant_collection_name,
+        embeddings_size=config.embedding_size,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import importlib
 import os
 from collections.abc import Iterator, Mapping
-from contextlib import ExitStack
 from pathlib import Path
 from typing import Any, Literal
 from unittest.mock import patch
@@ -123,22 +122,35 @@ def block_external_http(monkeypatch: pytest.MonkeyPatch, request: pytest.Fixture
 
 @pytest.fixture(scope="session")
 def app() -> Iterator[FastAPI]:
-    """Import the FastAPI app with expensive startup side effects patched out."""
-    with ExitStack() as stack:
-        stack.enter_context(patch("agent.utils.vdb.initialize_all_vector_dbs", return_value=None))
-        stack.enter_context(patch("phoenix.otel.register", return_value=None))
-        stack.enter_context(
-            patch("openinference.instrumentation.langchain.LangChainInstrumentor.instrument", return_value=None)
-        )
-
-        module = importlib.import_module("agent.api")
-        yield module.app
+    """Import the FastAPI app without running its lifespan."""
+    module = importlib.import_module("agent.api")
+    yield module.app
 
 
 @pytest.fixture
 def client(app: FastAPI) -> Iterator[TestClient]:
-    with TestClient(app) as test_client:
-        yield test_client
+    """Run the app with process resources replaced by network-free fakes."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from agent.utils.config import Config
+    from agent.utils.vdb import VDBResources
+
+    resources = VDBResources(
+        config=Config(),
+        sync_client=MagicMock(),
+        async_client=AsyncMock(),
+        sparse_embeddings=MagicMock(),
+    )
+    with (
+        patch("agent.api.create_vdb_resources", return_value=resources),
+        patch("agent.api.initialize_all_vector_dbs", new_callable=AsyncMock),
+        patch("agent.api.Graph") as graph_cls,
+        patch("agent.api.register", return_value=None),
+        patch("agent.api.LangChainInstrumentor.instrument", return_value=None),
+    ):
+        graph_cls.return_value.build_graph.return_value = MagicMock()
+        with TestClient(app) as test_client:
+            yield test_client
 
 
 @pytest.fixture(scope="session")

--- a/tests/e2e_tests/test_api.py
+++ b/tests/e2e_tests/test_api.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from http import HTTPStatus
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -15,10 +15,15 @@ def test_read_root(client) -> None:
     assert response.status_code == HTTPStatus.OK
 
 
-@patch("agent.routes.collection.initialize_vector_db_async", return_value=None)
-def test_create_collection(_mock_init_db, client) -> None:
+@patch("agent.routes.collection.initialize_vector_db_async", new_callable=AsyncMock)
+def test_create_collection(mock_init_db, client) -> None:
     collection_name = "test_collection"
     response = client.post(f"/collection/create/{collection_name}", params={"embeddings_size": 1536})
 
     assert response.status_code == HTTPStatus.OK
     assert response.json() == {"message": f"Collection {collection_name} created."}
+    mock_init_db.assert_awaited_once_with(
+        client=client.app.state.vdb_resources.async_client,
+        collection_name=collection_name,
+        embeddings_size=1536,
+    )

--- a/tests/unit_tests/test_api_lifespan.py
+++ b/tests/unit_tests/test_api_lifespan.py
@@ -1,0 +1,72 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+
+from agent.api import lifespan
+from agent.utils.config import Config
+from agent.utils.vdb import VDBResources
+
+
+@pytest.mark.anyio
+async def test_lifespan_constructs_initializes_and_closes_resources() -> None:
+    config = Config()
+    sync_client = MagicMock()
+    async_client = MagicMock()
+    async_client.close = AsyncMock()
+    resources = VDBResources(
+        config=config,
+        sync_client=sync_client,
+        async_client=async_client,
+        sparse_embeddings=MagicMock(),
+    )
+    graph = MagicMock()
+
+    with (
+        patch("agent.api.Config", return_value=config) as config_cls,
+        patch("agent.api.create_vdb_resources", return_value=resources) as create_resources,
+        patch("agent.api.initialize_all_vector_dbs", new_callable=AsyncMock) as initialize,
+        patch("agent.api.Graph") as graph_cls,
+        patch("agent.api.register", return_value=None),
+        patch("agent.api.LangChainInstrumentor.instrument", return_value=None),
+    ):
+        graph_cls.return_value.build_graph.return_value = graph
+        app = FastAPI()
+
+        async with lifespan(app):
+            assert app.state.vdb_resources is resources
+            assert app.state.graph is graph
+            sync_client.close.assert_not_called()
+            async_client.close.assert_not_awaited()
+
+        config_cls.assert_called_once_with()
+        create_resources.assert_called_once_with(config)
+        initialize.assert_awaited_once_with(config=config, client=async_client)
+        graph_cls.assert_called_once_with(config=config)
+        sync_client.close.assert_called_once_with()
+        async_client.close.assert_awaited_once_with()
+
+
+@pytest.mark.anyio
+async def test_lifespan_closes_resources_when_startup_fails() -> None:
+    sync_client = MagicMock()
+    async_client = MagicMock()
+    async_client.close = AsyncMock()
+    resources = VDBResources(
+        config=Config(),
+        sync_client=sync_client,
+        async_client=async_client,
+        sparse_embeddings=MagicMock(),
+    )
+
+    with (
+        patch("agent.api.Config", return_value=resources.config),
+        patch("agent.api.create_vdb_resources", return_value=resources),
+        patch("agent.api.initialize_all_vector_dbs", new_callable=AsyncMock, side_effect=RuntimeError("startup failed")),
+    ):
+        with pytest.raises(RuntimeError, match="startup failed"):
+            async with lifespan(FastAPI()):
+                pass
+
+    sync_client.close.assert_called_once_with()
+    async_client.close.assert_awaited_once_with()

--- a/tests/unit_tests/test_embedding_management.py
+++ b/tests/unit_tests/test_embedding_management.py
@@ -1,20 +1,36 @@
-import pytest
 from unittest.mock import MagicMock, patch
-from agent.backend.services.embedding_management import EmbeddingManagement
+
+import pytest
 from langchain_core.documents import Document
+
+from agent.backend.services.embedding_management import EmbeddingManagement
+from agent.utils.vdb import VDBResources
+
 
 @pytest.fixture
 def mock_config():
-    with patch("agent.backend.services.embedding_management.config") as mock_cfg:
-        mock_cfg.embedding_provider = "cohere"
-        mock_cfg.embedding_model_name = "embed-english-v3.0"
-        mock_cfg.embedding_size = 1024
-        yield mock_cfg
+    config = MagicMock()
+    config.embedding_provider = "cohere"
+    config.embedding_model_name = "embed-english-v3.0"
+    config.embedding_size = 1024
+    return config
+
+
+@pytest.fixture
+def resources(mock_config):
+    return VDBResources(
+        config=mock_config,
+        sync_client=MagicMock(),
+        async_client=MagicMock(),
+        sparse_embeddings=MagicMock(),
+    )
+
 
 @pytest.fixture
 def mock_init_vdb():
     with patch("agent.backend.services.embedding_management.init_vdb") as mock_vdb:
         yield mock_vdb
+
 
 @pytest.fixture
 def mock_get_embedding_model():
@@ -22,68 +38,76 @@ def mock_get_embedding_model():
         mock_embed.return_value = MagicMock()
         yield mock_embed
 
-@pytest.fixture
-def embedding_service(mock_config, mock_init_vdb, mock_get_embedding_model):
-    return EmbeddingManagement(collection_name="test_collection")
 
-def test_init_success(mock_config, mock_init_vdb, mock_get_embedding_model):
-    service = EmbeddingManagement(collection_name="test_collection")
+@pytest.fixture
+def embedding_service(resources, mock_init_vdb, mock_get_embedding_model):
+    return EmbeddingManagement(collection_name="test_collection", resources=resources)
+
+
+def test_init_success(mock_config, resources, mock_init_vdb, mock_get_embedding_model):
+    service = EmbeddingManagement(collection_name="test_collection", resources=resources)
 
     assert service.collection_name == "test_collection"
     mock_get_embedding_model.assert_called_once_with(mock_config)
-    mock_init_vdb.assert_called_once()
+    mock_init_vdb.assert_called_once_with(
+        resources=resources,
+        collection_name="test_collection",
+        embedding=mock_get_embedding_model.return_value,
+    )
 
-def test_init_invalid_provider(mock_config):
+
+def test_init_invalid_provider(mock_config, resources):
     mock_config.embedding_provider = "unknown_provider"
 
     with pytest.raises(KeyError, match="No suitable embedding Model configured!"):
-        EmbeddingManagement(collection_name="test_collection")
+        EmbeddingManagement(collection_name="test_collection", resources=resources)
+
 
 @patch("agent.backend.services.embedding_management.DirectoryLoader")
 @patch("agent.backend.services.embedding_management.RecursiveCharacterTextSplitter")
 def test_embed_documents_pdf(mock_splitter_cls, mock_loader_cls, embedding_service):
-    # Setup mocks
     mock_loader = MagicMock()
     mock_loader_cls.return_value = mock_loader
 
     mock_doc = Document(page_content="test content", metadata={"source": "/path/to/test.pdf"})
     mock_loader.load_and_split.return_value = [mock_doc]
 
-    # Call method
     embedding_service.embed_documents(directory="tests/resources/", file_ending=".pdf")
 
-    # Assertions
     mock_loader_cls.assert_called_once()
     mock_loader.load_and_split.assert_called_once()
     embedding_service.vector_db.add_texts.assert_called_once()
 
-    # Verify metadata processing (source path cleanup)
     call_args = embedding_service.vector_db.add_texts.call_args
     assert call_args is not None
-    metadatas = call_args.kwargs.get("metadatas") or call_args[1] # handle both keyword and positional args if needed, though code uses kwargs
+    metadatas = call_args.kwargs["metadatas"]
     assert metadatas[0]["source"] == "test.pdf"
+
 
 @patch("agent.backend.services.embedding_management.DirectoryLoader")
 @patch("agent.backend.services.embedding_management.RecursiveCharacterTextSplitter")
 def test_embed_documents_txt(mock_splitter_cls, mock_loader_cls, embedding_service):
-    # Setup mocks
     mock_loader = MagicMock()
     mock_loader_cls.return_value = mock_loader
     mock_loader.load_and_split.return_value = []
 
-    # Call method
     embedding_service.embed_documents(directory="tests/resources/", file_ending=".txt")
 
-    # Assertions
     mock_loader_cls.assert_called_once()
+
 
 def test_embed_documents_invalid_extension(embedding_service):
     with pytest.raises(ValueError, match="File ending not supported."):
         embedding_service.embed_documents(directory="tests/resources/", file_ending=".docx")
 
+
 @patch("agent.backend.services.embedding_management.generate_collection")
-def test_create_collection(mock_generate_collection, embedding_service):
+def test_create_collection(mock_generate_collection, embedding_service, resources):
     result = embedding_service.create_collection(name="new_collection")
 
     assert result is True
-    mock_generate_collection.assert_called_once_with("new_collection", 1024)
+    mock_generate_collection.assert_called_once_with(
+        client=resources.sync_client,
+        collection_name="new_collection",
+        embeddings_size=1024,
+    )

--- a/tests/unit_tests/test_rag_graph.py
+++ b/tests/unit_tests/test_rag_graph.py
@@ -3,12 +3,24 @@ from unittest.mock import MagicMock, AsyncMock, patch
 from langchain_core.messages import HumanMessage, AIMessage
 from langchain_core.documents import Document
 
+from agent.utils.config import Config
+from agent.utils.vdb import VDBResources
+
 # Patch reranker and retriever before importing Graph to prevent external connections
 with patch("agent.utils.reranker.get_reranker", return_value=lambda docs, query: docs):
     from agent.backend.graph import Graph
     from agent.backend.state import AgentState, Grade
 
 # --- Tests for Graph Class ---
+
+@pytest.fixture
+def vdb_resources():
+    return VDBResources(
+        config=Config(),
+        sync_client=MagicMock(),
+        async_client=MagicMock(),
+        sparse_embeddings=MagicMock(),
+    )
 
 @pytest.fixture
 def graph_instance():
@@ -55,23 +67,30 @@ def test_route_to_response_synthesizer_cohere(graph_instance):
     assert result == "response_synthesizer_cohere"
 
 @patch("agent.backend.nodes.retrieval.get_retriever")
-def test_retrieve_documents(mock_get_retriever, graph_instance):
+def test_retrieve_documents(mock_get_retriever, graph_instance, vdb_resources):
     mock_retriever = MagicMock()
     mock_retriever.invoke.return_value = [Document(page_content="doc1")]
     mock_get_retriever.return_value = mock_retriever
 
     state = {"messages": [HumanMessage(content="query")]}
-    config = {"metadata": {"collection_name": "test_coll"}}
+    config = {
+        "metadata": {"collection_name": "test_coll"},
+        "configurable": {"vdb_resources": vdb_resources},
+    }
 
     result = retrieve_documents(state, config, cfg=graph_instance.cfg)
 
     assert result["query"] == "query"
     assert len(result["documents"]) == 1
     assert result["documents"][0].page_content == "doc1"
-    mock_get_retriever.assert_called_with(collection_name="test_coll", k=graph_instance.cfg.retrieval_k)
+    mock_get_retriever.assert_called_with(
+        resources=vdb_resources,
+        collection_name="test_coll",
+        k=graph_instance.cfg.retrieval_k,
+    )
 
 @patch("agent.backend.nodes.retrieval.get_retriever")
-def test_retrieve_documents_with_chat_history(mock_get_retriever, graph_instance):
+def test_retrieve_documents_with_chat_history(mock_get_retriever, graph_instance, vdb_resources):
     # Mock the retriever
     mock_retriever = MagicMock()
     mock_retriever.invoke.return_value = [Document(page_content="doc1")]
@@ -121,7 +140,10 @@ def test_retrieve_documents_with_chat_history(mock_get_retriever, graph_instance
                 HumanMessage(content="followup")
             ]
         }
-        config = {"metadata": {"collection_name": "test_coll"}}
+        config = {
+            "metadata": {"collection_name": "test_coll"},
+            "configurable": {"vdb_resources": vdb_resources},
+        }
 
         result = retrieve_documents_with_chat_history(state, config, cfg=graph_instance.cfg, llm=graph_instance.llm)
 
@@ -317,8 +339,8 @@ def test_generate_response(graph_instance):
 
 # --- Tests for RAG Routes ---
 
-@patch("agent.routes.rag.graph")
-def test_rag_question_answer(mock_graph, client):
+def test_rag_question_answer(client):
+    mock_graph = client.app.state.graph
     # Mock the graph.ainvoke method
     mock_graph.with_config.return_value.ainvoke = AsyncMock(return_value={
         "documents": [Document(page_content="doc1", metadata={"source": "test"})],
@@ -337,9 +359,12 @@ def test_rag_question_answer(mock_graph, client):
     assert data["answer"] == "The answer"
     assert len(data["meta_data"]) == 1
     assert data["meta_data"][0]["document"][0] == "doc1"
+    run_config = mock_graph.with_config.call_args.args[0]
+    assert run_config["metadata"]["collection_name"] == "test"
+    assert run_config["configurable"]["vdb_resources"] is client.app.state.vdb_resources
 
-@patch("agent.routes.rag.graph")
-def test_rag_stream(mock_graph, client):
+def test_rag_stream(client):
+    mock_graph = client.app.state.graph
     # Mock the graph.astream_events method
     async def mock_stream(*args, **kwargs):
         yield {

--- a/tests/unit_tests/test_routes_embeddings.py
+++ b/tests/unit_tests/test_routes_embeddings.py
@@ -38,17 +38,24 @@ async def test_post_embed_documents_success(mock_write, mock_service_cls, mock_t
     mock_file.filename = "test.pdf"
     mock_file.read = AsyncMock(return_value=b"content")
 
-    response = await post_embed_documents(collection_name="test_collection", files=[mock_file], file_ending=".pdf")
+    resources = MagicMock()
+    response = await post_embed_documents(
+        collection_name="test_collection",
+        files=[mock_file],
+        resources=resources,
+        file_ending=".pdf",
+    )
 
     assert response.status == "success"
     assert response.files == ["test.pdf"]
     mock_write.assert_called_once()
+    mock_service_cls.assert_called_once_with(collection_name="test_collection", resources=resources)
     mock_service_cls.return_value.embed_documents.assert_called_once()
 
 
 async def test_post_embed_documents_no_files() -> None:
     with pytest.raises(HTTPException) as exc:
-        await post_embed_documents(collection_name="test", files=[])
+        await post_embed_documents(collection_name="test", files=[], resources=MagicMock())
 
     assert exc.value.status_code == status.HTTP_400_BAD_REQUEST
     assert exc.value.detail == "No files were uploaded."
@@ -65,7 +72,7 @@ async def test_post_embed_documents_write_error(mock_write, mock_tmp_folder, tmp
     mock_file.read = AsyncMock(return_value=b"content")
 
     with pytest.raises(HTTPException) as exc:
-        await post_embed_documents(collection_name="test", files=[mock_file])
+        await post_embed_documents(collection_name="test", files=[mock_file], resources=MagicMock())
 
     assert exc.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert "file writing error" in exc.value.detail
@@ -85,7 +92,7 @@ async def test_post_embed_documents_embedding_error(mock_write, mock_service_cls
     mock_file.read = AsyncMock(return_value=b"content")
 
     with pytest.raises(HTTPException) as exc:
-        await post_embed_documents(collection_name="test", files=[mock_file])
+        await post_embed_documents(collection_name="test", files=[mock_file], resources=MagicMock())
 
     assert exc.value.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR
     assert "Failed to embed" in exc.value.detail
@@ -103,9 +110,15 @@ async def test_embedd_text_success(mock_aio_open, mock_service_cls, mock_tmp_fol
 
     request = EmbeddTextRequest(text="some text", file_name="test_doc")
 
-    response = await embedd_text(embedding=request, collection_name="test_collection")
+    resources = MagicMock()
+    response = await embedd_text(
+        embedding=request,
+        collection_name="test_collection",
+        resources=resources,
+    )
 
     assert response.status == "success"
     assert response.files == ["test_doc"]
     mock_file.write.assert_called_once_with("some text")
+    mock_service_cls.assert_called_once_with(collection_name="test_collection", resources=resources)
     mock_service_cls.return_value.embed_documents.assert_called_once()

--- a/tests/unit_tests/test_search_delete.py
+++ b/tests/unit_tests/test_search_delete.py
@@ -5,8 +5,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from inline_snapshot import snapshot
 from qdrant_client.http.models.models import UpdateResult
 
-from agent.utils import retriever as retriever_module
+from agent.utils.config import Config
 from agent.utils.retriever import get_retriever
+from agent.utils.vdb import VDBResources
 from tests.fakes.rag import FakeAsyncRetriever, FakeDoc
 
 
@@ -39,7 +40,11 @@ def test_delete_vector(mock_delete, client) -> None:
 
     assert response.status_code == 200
     assert response.json()["status"] == "completed"
-    mock_delete.assert_awaited_once_with(collection_name="test_coll", source="test.pdf")
+    mock_delete.assert_awaited_once_with(
+        client=client.app.state.vdb_resources.async_client,
+        collection_name="test_coll",
+        source="test.pdf",
+    )
 
 
 @patch("agent.utils.retriever.get_vector_store")
@@ -48,12 +53,21 @@ def test_get_retriever(mock_get_embedding_model, mock_get_vector_store) -> None:
     mock_vstore_instance = MagicMock()
     mock_get_vector_store.return_value = mock_vstore_instance
 
-    retriever_module._embeddings_cache.clear()
+    resources = VDBResources(
+        config=Config(),
+        sync_client=MagicMock(),
+        async_client=MagicMock(),
+        sparse_embeddings=MagicMock(),
+    )
     mock_embedding = MagicMock()
     mock_get_embedding_model.return_value = mock_embedding
 
-    get_retriever(k=5, collection_name="my_coll")
+    get_retriever(resources=resources, k=5, collection_name="my_coll")
 
-    mock_get_embedding_model.assert_called_once()
-    mock_get_vector_store.assert_called_once_with(collection_name="my_coll", embedding=mock_embedding)
+    mock_get_embedding_model.assert_called_once_with(resources.config)
+    mock_get_vector_store.assert_called_once_with(
+        resources=resources,
+        collection_name="my_coll",
+        embedding=mock_embedding,
+    )
     mock_vstore_instance.as_retriever.assert_called_with(search_kwargs={"k": 5})

--- a/tests/unit_tests/test_vdb.py
+++ b/tests/unit_tests/test_vdb.py
@@ -1,9 +1,13 @@
+import subprocess
+import sys
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from agent.utils.config import Config
 from agent.utils.vdb import (
+    VDBResources,
+    create_vdb_resources,
     delete_documents_by_source,
     get_vector_store,
     init_vdb,
@@ -11,77 +15,136 @@ from agent.utils.vdb import (
     initialize_vector_db,
 )
 
-@patch("agent.utils.vdb.load_vec_db_conn")
-def test_initialize_vector_db_exists(mock_load_conn):
-    mock_client = MagicMock()
-    mock_client.collection_exists.return_value = True
-    mock_load_conn.return_value = mock_client
 
-    initialize_vector_db("test_coll", 1536)
+def test_import_does_not_construct_resources() -> None:
+    code = """
+from unittest.mock import patch
+with (
+    patch('agent.utils.config.Config', side_effect=AssertionError('Config constructed')),
+    patch('qdrant_client.QdrantClient', side_effect=AssertionError('sync client constructed')),
+    patch('qdrant_client.AsyncQdrantClient', side_effect=AssertionError('async client constructed')),
+    patch('langchain_qdrant.FastEmbedSparse', side_effect=AssertionError('sparse embeddings constructed')),
+):
+    import agent.utils.vdb
+"""
+    subprocess.run([sys.executable, "-c", code], check=True)
 
-    mock_client.collection_exists.assert_called_with(collection_name="test_coll")
-    # Should NOT call create_collection
-    mock_client.create_collection.assert_not_called()
 
-@patch("agent.utils.vdb.load_vec_db_conn")
-def test_initialize_vector_db_not_exists(mock_load_conn):
-    mock_client = MagicMock()
-    mock_client.collection_exists.return_value = False
-    mock_load_conn.return_value = mock_client
+def make_resources() -> VDBResources:
+    async_client = MagicMock()
+    async_client.close = AsyncMock()
+    return VDBResources(
+        config=Config(),
+        sync_client=MagicMock(),
+        async_client=async_client,
+        sparse_embeddings=MagicMock(),
+    )
 
-    initialize_vector_db("test_coll", 1536)
 
-    mock_client.collection_exists.assert_called_with(collection_name="test_coll")
-    mock_client.create_collection.assert_called_once()
-    mock_client.set_sparse_model.assert_called_with(embedding_model_name="Qdrant/bm25")
+@patch("agent.utils.vdb.FastEmbedSparse")
+@patch("agent.utils.vdb.AsyncQdrantClient")
+@patch("agent.utils.vdb.QdrantClient")
+def test_create_vdb_resources_constructs_owned_resources(sync_client_cls, async_client_cls, sparse_cls):
+    config = Config(qdrant_url="http://qdrant", qdrant_port=6334)
+
+    resources = create_vdb_resources(config)
+
+    assert resources.config is config
+    assert resources.sync_client is sync_client_cls.return_value
+    assert resources.async_client is async_client_cls.return_value
+    assert resources.sparse_embeddings is sparse_cls.return_value
+    sync_client_cls.assert_called_once_with(
+        location="http://qdrant",
+        port=6334,
+        api_key=config.qdrant_api_key,
+        prefer_grpc=config.qdrant_prefer_grpc,
+    )
+    async_client_cls.assert_called_once_with(
+        location="http://qdrant",
+        port=6334,
+        api_key=config.qdrant_api_key,
+        prefer_grpc=config.qdrant_prefer_grpc,
+    )
+
+
+def test_initialize_vector_db_exists():
+    client = MagicMock()
+    client.collection_exists.return_value = True
+
+    initialize_vector_db(client, "test_coll", 1536)
+
+    client.collection_exists.assert_called_with(collection_name="test_coll")
+    client.create_collection.assert_not_called()
+
+
+def test_initialize_vector_db_not_exists():
+    client = MagicMock()
+    client.collection_exists.return_value = False
+
+    initialize_vector_db(client, "test_coll", 1536)
+
+    client.collection_exists.assert_called_with(collection_name="test_coll")
+    client.create_collection.assert_called_once()
+    client.set_sparse_model.assert_called_with(embedding_model_name="Qdrant/bm25")
+
 
 @patch("agent.utils.vdb.QdrantVectorStore")
-@patch("agent.utils.vdb.FastEmbedSparse")
-def test_init_vdb(_mock_sparse, mock_vstore):
-    mock_embedding = MagicMock()
+def test_init_vdb_uses_sync_client(mock_vstore):
+    resources = make_resources()
+    embedding = MagicMock()
 
-    init_vdb("test_coll", mock_embedding)
+    init_vdb(resources, "test_coll", embedding)
 
     mock_vstore.assert_called_once()
-    args, kwargs = mock_vstore.call_args
+    kwargs = mock_vstore.call_args.kwargs
+    assert kwargs["client"] is resources.sync_client
     assert kwargs["collection_name"] == "test_coll"
-    assert kwargs["embedding"] == mock_embedding
+    assert kwargs["embedding"] is embedding
+    assert kwargs["sparse_embedding"] is resources.sparse_embeddings
 
-def test_get_vector_store_is_cached():
+
+def test_get_vector_store_is_cached_per_resource():
+    resources = make_resources()
     with patch("agent.utils.vdb.init_vdb") as mock_init_vdb:
-        import agent.utils.vdb as vdb
-
-        vdb._vector_store_cache.clear()
-        mock_store = MagicMock()
-        mock_init_vdb.return_value = mock_store
+        store = MagicMock()
+        mock_init_vdb.return_value = store
         embedding = MagicMock()
 
-        assert get_vector_store("test_coll", embedding) is mock_store
-        assert get_vector_store("test_coll", embedding) is mock_store
+        assert get_vector_store(resources, "test_coll", embedding) is store
+        assert get_vector_store(resources, "test_coll", embedding) is store
 
-        mock_init_vdb.assert_called_once_with(collection_name="test_coll", embedding=embedding)
+        mock_init_vdb.assert_called_once_with(
+            resources=resources,
+            collection_name="test_coll",
+            embedding=embedding,
+        )
 
 
 @pytest.mark.anyio
-@patch("agent.utils.vdb.get_async_qdrant_client")
-async def test_delete_documents_by_source(mock_get_client):
-    mock_client = AsyncMock()
-    mock_get_client.return_value = mock_client
+async def test_delete_documents_by_source_uses_async_client():
+    client = MagicMock()
+    client.delete = AsyncMock()
 
-    await delete_documents_by_source(collection_name="test_coll", source="test.pdf")
+    await delete_documents_by_source(client=client, collection_name="test_coll", source="test.pdf")
 
-    mock_client.delete.assert_awaited_once()
-    call = mock_client.delete.call_args.kwargs
+    client.delete.assert_awaited_once()
+    call = client.delete.call_args.kwargs
     assert call["collection_name"] == "test_coll"
     condition = call["points_selector"].filter.must[0]
     assert condition.key == "metadata.source"
     assert condition.match.value == "test.pdf"
 
 
-@patch("agent.utils.vdb.initialize_vector_db")
-def test_initialize_all_vector_dbs(mock_init_vdb):
+@pytest.mark.anyio
+@patch("agent.utils.vdb.initialize_vector_db_async", new_callable=AsyncMock)
+async def test_initialize_all_vector_dbs_uses_async_client(mock_init_vdb):
     config = Config()
-    # We can mock config values if needed, but default is fine
-    initialize_all_vector_dbs(config)
+    client = MagicMock()
 
-    mock_init_vdb.assert_called_once()
+    await initialize_all_vector_dbs(config, client)
+
+    mock_init_vdb.assert_awaited_once_with(
+        client=client,
+        collection_name=config.qdrant_collection_name,
+        embeddings_size=config.embedding_size,
+    )


### PR DESCRIPTION
## Summary

- create synchronous and asynchronous Qdrant clients once during FastAPI lifespan startup
- keep settings, clients, sparse embeddings, embedding cache, and vector-store cache in a typed `VDBResources` container on `app.state`
- inject resources explicitly through routes, LangGraph runnable configuration, retrievers, embedding management, and scripts
- initialize the default collection asynchronously and close both clients reliably during shutdown
- remove import-time Qdrant, FastEmbed, and settings construction from the VDB module

## Context

This is the lifecycle-management follow-up to #221. The synchronous client remains necessary because `QdrantVectorStore` requires `QdrantClient`; asynchronous routes use `AsyncQdrantClient` to avoid blocking the event loop.

## Verification

- `uv run pytest -q -m 'not vcr and not e2e' tests/` — 60 passed, 4 deselected
- VCR replay suite — 3 passed, 61 deselected
- targeted changed-area suite — 41 passed
- `uv run prek run --all-files` — passed
- Ruff check and format — passed
- `ty check src/agent` — no configured errors
- OpenAPI and Uvicorn startup smoke tests — passed

No live Qdrant/network test was run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Reliability**
  - Improved application startup and shutdown handling, including safer cleanup when initialization fails.
  - Improved stability for search, document management, embeddings, and question-answering operations through shared application resources.
  - Vector database connections and caches are now managed consistently throughout the application lifecycle.

- **Bug Fixes**
  - Fixed resource handling across synchronous, streaming, and OpenAI-compatible request flows.
  - Improved validation when retrieval resources are unavailable or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->