### PR TITLE
feat(api): add OpenAI-compatible Chat and Responses APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Supported subset:
 
 - Chat Completions: `model`, `messages`, and `stream`; messages use string `content`, `user`/`assistant` roles, and end with a `user` message.
 - Responses: `model`, `input`, and `stream`; input is either a string or the same text-message history subset.
-- Text answers only. Chat streams terminate with `[DONE]`; Responses streams terminate after `response.completed`.
-- OpenAI-style error envelopes for invalid `/v1` requests. Token usage is omitted because the RAG graph does not provide reliable totals.
+- Text answers only. Successful Chat streams terminate with `[DONE]`; successful Responses streams terminate after `response.completed`. Mid-stream failures emit SDK-compatible error events without a success terminator.
+- OpenAI-style error envelopes for invalid `/v1` requests. Because the RAG graph does not provide reliable token totals, Chat usage is omitted and Responses usage is `null`.
 
 Unsupported fields are rejected rather than ignored. This includes system/developer/tool messages, `instructions`, tools and function calling, multimodal content, structured outputs, previous-response or conversation state, sampling/token controls, storage, and metadata. The compatibility responses contain the generated answer, not the RAG citation metadata available from `/rag`.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This is a Rest-Backend for a Conversational Agent, that allows you to embed Docu
   - [LLMs and Backend Providers](#llms-and-backend-providers)
   - [Quickstart](#quickstart)
   - [Project Description](#project-description)
+  - [OpenAI-compatible API subset](#openai-compatible-api-subset)
   - [What is RAG?](#what-is-rag)
   - [Tracing](#tracing)
   - [Semantic Search](#semantic-search)
@@ -76,6 +77,30 @@ Then start the system with
 
 ## Project Description
 This project is a conversational rag agent that uses Google Gemini Large Language Models to generate responses to user queries. The agent also includes a vector database and a REST API built with FastAPI.
+
+## OpenAI-compatible API subset
+
+The backend exposes `POST /v1/chat/completions` and `POST /v1/responses` for clients that use the OpenAI HTTP contract. Both endpoints support non-streaming and SSE streaming and run the same LangGraph RAG pipeline as `/rag`.
+
+Configure the public model alias and collection independently:
+
+```bash
+OPENAI_COMPATIBLE_MODEL=rag
+QDRANT_COLLECTION_NAME=default
+```
+
+The request `model` must equal `OPENAI_COMPATIBLE_MODEL`. It never selects a Qdrant collection; retrieval always uses the server-controlled `QDRANT_COLLECTION_NAME`.
+
+Supported subset:
+
+- Chat Completions: `model`, `messages`, and `stream`; messages use string `content`, `user`/`assistant` roles, and end with a `user` message.
+- Responses: `model`, `input`, and `stream`; input is either a string or the same text-message history subset.
+- Text answers only. Chat streams terminate with `[DONE]`; Responses streams terminate after `response.completed`.
+- OpenAI-style error envelopes for invalid `/v1` requests. Token usage is omitted because the RAG graph does not provide reliable totals.
+
+Unsupported fields are rejected rather than ignored. This includes system/developer/tool messages, `instructions`, tools and function calling, multimodal content, structured outputs, previous-response or conversation state, sampling/token controls, storage, and metadata. The compatibility responses contain the generated answer, not the RAG citation metadata available from `/rag`.
+
+For the Python SDK, set `base_url` to the backend's `/v1` URL and use the configured alias as `model`.
 
 ## What is RAG?
 Retrieval-Augmented Generation (RAG) is a technique that enhances Large Language Models (LLMs) by providing them with relevant information from an external knowledge base. Instead of relying solely on its pre-trained knowledge, the model retrieves specific documents related to the user's query and uses them as context to generate more accurate, up-to-date, and domain-specific responses. This approach reduces hallucinations and allows the model to answer questions about private or proprietary data.

--- a/src/agent/api.py
+++ b/src/agent/api.py
@@ -54,6 +54,10 @@ app = FastAPI()
 app.openapi = my_schema
 
 
+def _is_openai_path(path: str) -> bool:
+    return path == "/v1" or path.startswith("/v1/")
+
+
 def _openai_error_response(*, status_code: int, message: str, error_type: str, param: str | None, code: str) -> JSONResponse:
     return JSONResponse(
         status_code=status_code,
@@ -83,7 +87,7 @@ async def openai_api_exception_handler(_request: Request, exc: openai_compat.Ope
 @app.exception_handler(StarletteHTTPException)
 async def http_error_exception_handler(request: Request, exc: StarletteHTTPException) -> Response:
     """Use OpenAI error envelopes for HTTP errors below the compatibility prefix."""
-    if not request.url.path.startswith("/v1/"):
+    if not _is_openai_path(request.url.path):
         return await http_exception_handler(request, exc)
 
     return _openai_error_response(
@@ -98,7 +102,7 @@ async def http_error_exception_handler(request: Request, exc: StarletteHTTPExcep
 @app.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError) -> Response:
     """Use OpenAI validation envelopes only below the compatibility prefix."""
-    if not request.url.path.startswith("/v1/"):
+    if not _is_openai_path(request.url.path):
         return await request_validation_exception_handler(request, exc)
 
     error = exc.errors()[0]
@@ -119,7 +123,7 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
 async def global_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     """Global exception handler."""
     logger.error(f"Global error: {exc}")
-    if request.url.path.startswith("/v1/"):
+    if _is_openai_path(request.url.path):
         return _openai_error_response(
             status_code=500,
             message="Internal server error.",

--- a/src/agent/api.py
+++ b/src/agent/api.py
@@ -3,13 +3,16 @@
 import pyfiglet
 from dotenv import load_dotenv
 from fastapi import FastAPI, Request
+from fastapi.exception_handlers import http_exception_handler, request_validation_exception_handler
+from fastapi.exceptions import RequestValidationError
 from fastapi.openapi.utils import get_openapi
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 from loguru import logger
 from openinference.instrumentation.langchain import LangChainInstrumentor
 from phoenix.otel import register
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
-from agent.routes import collection, delete, embeddings, rag, search
+from agent.routes import collection, delete, embeddings, openai_compat, rag, search
 from agent.utils.config import Config
 from agent.utils.vdb import initialize_all_vector_dbs
 
@@ -41,6 +44,8 @@ def my_schema() -> dict:
         description="Chat with your Documents using Large Language Models.",
         routes=app.routes,
     )
+    for path in ("/v1/chat/completions", "/v1/responses"):
+        openapi_schema["paths"][path]["post"]["responses"].pop("422", None)
     app.openapi_schema = openapi_schema
     return app.openapi_schema
 
@@ -49,10 +54,79 @@ app = FastAPI()
 app.openapi = my_schema
 
 
+def _openai_error_response(*, status_code: int, message: str, error_type: str, param: str | None, code: str) -> JSONResponse:
+    return JSONResponse(
+        status_code=status_code,
+        content={
+            "error": {
+                "message": message,
+                "type": error_type,
+                "param": param,
+                "code": code,
+            }
+        },
+    )
+
+
+@app.exception_handler(openai_compat.OpenAIAPIError)
+async def openai_api_exception_handler(_request: Request, exc: openai_compat.OpenAIAPIError) -> JSONResponse:
+    """Render explicit OpenAI compatibility errors."""
+    return _openai_error_response(
+        status_code=exc.status_code,
+        message=exc.message,
+        error_type=exc.error_type,
+        param=exc.param,
+        code=exc.code,
+    )
+
+
+@app.exception_handler(StarletteHTTPException)
+async def http_error_exception_handler(request: Request, exc: StarletteHTTPException) -> Response:
+    """Use OpenAI error envelopes for HTTP errors below the compatibility prefix."""
+    if not request.url.path.startswith("/v1/"):
+        return await http_exception_handler(request, exc)
+
+    return _openai_error_response(
+        status_code=exc.status_code,
+        message=str(exc.detail),
+        error_type="invalid_request_error" if exc.status_code < 500 else "server_error",
+        param=None,
+        code="not_found" if exc.status_code == 404 else "http_error",
+    )
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError) -> Response:
+    """Use OpenAI validation envelopes only below the compatibility prefix."""
+    if not request.url.path.startswith("/v1/"):
+        return await request_validation_exception_handler(request, exc)
+
+    error = exc.errors()[0]
+    location = [str(part) for part in error["loc"] if part != "body"]
+    param = ".".join(location) or None
+    unsupported = error["type"] == "extra_forbidden"
+    message = f"Unsupported field: `{param}`." if unsupported else error["msg"]
+    return _openai_error_response(
+        status_code=400,
+        message=message,
+        error_type="invalid_request_error",
+        param=param,
+        code="unsupported_parameter" if unsupported else "invalid_value",
+    )
+
+
 @app.exception_handler(Exception)
-async def global_exception_handler(_request: Request, exc: Exception) -> JSONResponse:
+async def global_exception_handler(request: Request, exc: Exception) -> JSONResponse:
     """Global exception handler."""
     logger.error(f"Global error: {exc}")
+    if request.url.path.startswith("/v1/"):
+        return _openai_error_response(
+            status_code=500,
+            message="Internal server error.",
+            error_type="server_error",
+            param=None,
+            code="internal_error",
+        )
     return JSONResponse(
         status_code=500,
         content={"error": "Internal Server Error", "details": str(exc)},
@@ -66,6 +140,7 @@ app.include_router(router=embeddings.router, prefix="/embeddings")
 app.include_router(router=search.router, prefix="/semantic")
 app.include_router(router=rag.router, prefix="/rag")
 app.include_router(router=delete.router, prefix="/embeddings")
+app.include_router(router=openai_compat.router)
 
 
 @app.get(path="/", tags=["root"])

--- a/src/agent/data_model/openai_compat.py
+++ b/src/agent/data_model/openai_compat.py
@@ -2,7 +2,7 @@
 
 from typing import Any, Literal, Self
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, model_validator
 
 
 class StrictOpenAIRequest(BaseModel):
@@ -23,7 +23,7 @@ class ChatCompletionRequest(StrictOpenAIRequest):
 
     model: str = Field(min_length=1, description="Configured public RAG model alias.")
     messages: list[ChatCompletionMessageRequest] = Field(min_length=1)
-    stream: bool = False
+    stream: StrictBool = False
 
     @model_validator(mode="after")
     def require_final_user_message(self) -> Self:
@@ -46,7 +46,7 @@ class ResponsesRequest(StrictOpenAIRequest):
 
     model: str = Field(min_length=1, description="Configured public RAG model alias.")
     input: str | list[ResponseInputMessage]
-    stream: bool = False
+    stream: StrictBool = False
 
     @model_validator(mode="after")
     def validate_input(self) -> Self:
@@ -82,23 +82,25 @@ class OpenAIErrorResponse(BaseModel):
 class ChatCompletionResponseMessage(BaseModel):
     """Assistant message returned in a Chat Completion."""
 
-    role: Literal["assistant"] = "assistant"
+    role: Literal["assistant"]
     content: str
+    refusal: None
 
 
 class ChatCompletionChoice(BaseModel):
     """Single RAG answer choice."""
 
-    index: Literal[0] = 0
+    index: Literal[0]
     message: ChatCompletionResponseMessage
-    finish_reason: Literal["stop"] = "stop"
+    logprobs: None
+    finish_reason: Literal["stop"]
 
 
 class ChatCompletionResponse(BaseModel):
     """OpenAI-compatible non-streaming Chat Completion."""
 
     id: str
-    object: Literal["chat.completion"] = "chat.completion"
+    object: Literal["chat.completion"]
     created: int
     model: str
     choices: list[ChatCompletionChoice]
@@ -107,33 +109,45 @@ class ChatCompletionResponse(BaseModel):
 class ResponseOutputText(BaseModel):
     """Text content in a Responses output message."""
 
-    type: Literal["output_text"] = "output_text"
+    type: Literal["output_text"]
     text: str
-    annotations: list[dict[str, Any]] = Field(default_factory=list)
+    annotations: list[dict[str, Any]]
 
 
 class ResponseOutputMessage(BaseModel):
     """Assistant output item in a Responses object."""
 
     id: str
-    type: Literal["message"] = "message"
-    status: Literal["in_progress", "completed"]
-    role: Literal["assistant"] = "assistant"
+    type: Literal["message"]
+    status: Literal["in_progress", "completed", "incomplete"]
+    role: Literal["assistant"]
     content: list[ResponseOutputText]
 
 
+class ResponseFailure(BaseModel):
+    """Failure details on a failed Responses object."""
+
+    code: Literal["server_error"]
+    message: str
+
+
 class ResponsesResponse(BaseModel):
-    """OpenAI-compatible non-streaming Responses object."""
+    """OpenAI-compatible Responses object for this text-only subset."""
 
     id: str
-    object: Literal["response"] = "response"
+    object: Literal["response"]
     created_at: float
-    status: Literal["in_progress", "completed"]
-    completed_at: float | None = None
-    error: None = None
-    incomplete_details: None = None
+    status: Literal["in_progress", "completed", "failed"]
+    completed_at: float | None
+    error: ResponseFailure | None
+    incomplete_details: None
+    instructions: None
+    metadata: dict[str, str]
     model: str
     output: list[ResponseOutputMessage]
-    parallel_tool_calls: Literal[False] = False
-    tool_choice: Literal["none"] = "none"
-    tools: list[dict[str, Any]] = Field(default_factory=list)
+    parallel_tool_calls: Literal[False]
+    temperature: float | None
+    tool_choice: Literal["none"]
+    tools: list[dict[str, Any]]
+    top_p: float | None
+    usage: None

--- a/src/agent/data_model/openai_compat.py
+++ b/src/agent/data_model/openai_compat.py
@@ -1,0 +1,139 @@
+"""Schemas for the supported OpenAI-compatible API subset."""
+
+from typing import Any, Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class StrictOpenAIRequest(BaseModel):
+    """Reject OpenAI request fields that this RAG API does not implement."""
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class ChatCompletionMessageRequest(StrictOpenAIRequest):
+    """A text-only user or assistant chat message."""
+
+    role: Literal["user", "assistant"]
+    content: str
+
+
+class ChatCompletionRequest(StrictOpenAIRequest):
+    """Supported request subset for Chat Completions."""
+
+    model: str = Field(min_length=1, description="Configured public RAG model alias.")
+    messages: list[ChatCompletionMessageRequest] = Field(min_length=1)
+    stream: bool = False
+
+    @model_validator(mode="after")
+    def require_final_user_message(self) -> Self:
+        """Require a question for the RAG pipeline to answer."""
+        if self.messages[-1].role != "user":
+            msg = "The final message must have role 'user'."
+            raise ValueError(msg)
+        return self
+
+
+class ResponseInputMessage(StrictOpenAIRequest):
+    """A text-only input message accepted by the Responses endpoint."""
+
+    role: Literal["user", "assistant"]
+    content: str
+
+
+class ResponsesRequest(StrictOpenAIRequest):
+    """Supported request subset for the Responses API."""
+
+    model: str = Field(min_length=1, description="Configured public RAG model alias.")
+    input: str | list[ResponseInputMessage]
+    stream: bool = False
+
+    @model_validator(mode="after")
+    def validate_input(self) -> Self:
+        """Require non-empty input ending in a user message."""
+        if isinstance(self.input, str):
+            if not self.input:
+                msg = "Input must not be empty."
+                raise ValueError(msg)
+        elif not self.input:
+            msg = "Input messages must not be empty."
+            raise ValueError(msg)
+        elif self.input[-1].role != "user":
+            msg = "The final input message must have role 'user'."
+            raise ValueError(msg)
+        return self
+
+
+class OpenAIErrorDetail(BaseModel):
+    """Error details used by the OpenAI-compatible routes."""
+
+    message: str
+    type: str
+    param: str | None
+    code: str
+
+
+class OpenAIErrorResponse(BaseModel):
+    """OpenAI-compatible error envelope."""
+
+    error: OpenAIErrorDetail
+
+
+class ChatCompletionResponseMessage(BaseModel):
+    """Assistant message returned in a Chat Completion."""
+
+    role: Literal["assistant"] = "assistant"
+    content: str
+
+
+class ChatCompletionChoice(BaseModel):
+    """Single RAG answer choice."""
+
+    index: Literal[0] = 0
+    message: ChatCompletionResponseMessage
+    finish_reason: Literal["stop"] = "stop"
+
+
+class ChatCompletionResponse(BaseModel):
+    """OpenAI-compatible non-streaming Chat Completion."""
+
+    id: str
+    object: Literal["chat.completion"] = "chat.completion"
+    created: int
+    model: str
+    choices: list[ChatCompletionChoice]
+
+
+class ResponseOutputText(BaseModel):
+    """Text content in a Responses output message."""
+
+    type: Literal["output_text"] = "output_text"
+    text: str
+    annotations: list[dict[str, Any]] = Field(default_factory=list)
+
+
+class ResponseOutputMessage(BaseModel):
+    """Assistant output item in a Responses object."""
+
+    id: str
+    type: Literal["message"] = "message"
+    status: Literal["in_progress", "completed"]
+    role: Literal["assistant"] = "assistant"
+    content: list[ResponseOutputText]
+
+
+class ResponsesResponse(BaseModel):
+    """OpenAI-compatible non-streaming Responses object."""
+
+    id: str
+    object: Literal["response"] = "response"
+    created_at: float
+    status: Literal["in_progress", "completed"]
+    completed_at: float | None = None
+    error: None = None
+    incomplete_details: None = None
+    model: str
+    output: list[ResponseOutputMessage]
+    parallel_tool_calls: Literal[False] = False
+    tool_choice: Literal["none"] = "none"
+    tools: list[dict[str, Any]] = Field(default_factory=list)

--- a/src/agent/routes/openai_compat.py
+++ b/src/agent/routes/openai_compat.py
@@ -1,0 +1,337 @@
+"""OpenAI-compatible endpoints backed by the existing RAG graph."""
+
+import json
+import time
+from collections.abc import AsyncIterator
+from typing import Any
+from uuid import uuid4
+
+from fastapi import APIRouter
+from fastapi.responses import StreamingResponse
+
+from agent.data_model.openai_compat import (
+    ChatCompletionChoice,
+    ChatCompletionRequest,
+    ChatCompletionResponse,
+    ChatCompletionResponseMessage,
+    OpenAIErrorResponse,
+    ResponseOutputMessage,
+    ResponseOutputText,
+    ResponsesRequest,
+    ResponsesResponse,
+)
+from agent.routes.rag import graph
+from agent.utils.config import Config
+
+_GENERATION_NODES = {"response_synthesizer", "response_synthesizer_cohere"}
+
+settings = Config()
+router = APIRouter(prefix="/v1", tags=["OpenAI compatibility"])
+
+
+class OpenAIAPIError(Exception):
+    """An error rendered with an OpenAI-compatible envelope."""
+
+    def __init__(self, *, status_code: int, message: str, error_type: str, param: str | None, code: str) -> None:
+        """Initialize a public API error."""
+        super().__init__(message)
+        self.status_code = status_code
+        self.message = message
+        self.error_type = error_type
+        self.param = param
+        self.code = code
+
+
+def _validate_model(model: str) -> None:
+    if model != settings.openai_compatible_model:
+        raise OpenAIAPIError(
+            status_code=404,
+            message=f"The model `{model}` does not exist or is not available.",
+            error_type="invalid_request_error",
+            param="model",
+            code="model_not_found",
+        )
+
+
+def _graph_config() -> dict[str, dict[str, str]]:
+    """Use the server-configured collection, independently of the public model alias."""
+    return {"metadata": {"collection_name": settings.qdrant_collection_name}}
+
+
+def _answer_text(chain_result: dict[str, Any]) -> str:
+    content = chain_result["messages"][-1].content
+    if not isinstance(content, str):
+        msg = "The RAG graph returned non-text output."
+        raise TypeError(msg)
+    return content
+
+
+def _request_messages(request: ChatCompletionRequest) -> list[dict[str, str]]:
+    return [message.model_dump() for message in request.messages]
+
+
+def _response_messages(request: ResponsesRequest) -> list[dict[str, str]]:
+    if isinstance(request.input, str):
+        return [{"role": "user", "content": request.input}]
+    return [message.model_dump() for message in request.input]
+
+
+async def _answer(messages: list[dict[str, str]]) -> str:
+    try:
+        result = await graph.with_config(_graph_config()).ainvoke({"messages": messages})
+        return _answer_text(result)
+    except Exception as exc:
+        raise OpenAIAPIError(
+            status_code=500,
+            message="Internal server error.",
+            error_type="server_error",
+            param=None,
+            code="internal_error",
+        ) from exc
+
+
+async def _text_deltas(messages: list[dict[str, str]]) -> AsyncIterator[str]:
+    events = graph.with_config(_graph_config()).astream_events({"messages": messages}, version="v2")
+    async for event in events:
+        if event.get("event") != "on_chat_model_stream" or event.get("metadata", {}).get("langgraph_node") not in _GENERATION_NODES:
+            continue
+        content = event["data"]["chunk"].content
+        if not content:
+            continue
+        if not isinstance(content, str):
+            msg = "The RAG graph returned a non-text stream chunk."
+            raise TypeError(msg)
+        yield content
+
+
+def _sse_data(payload: dict[str, Any]) -> str:
+    return f"data: {json.dumps(payload, separators=(',', ':'))}\n\n"
+
+
+def _response_sse(payload: dict[str, Any]) -> str:
+    return f"event: {payload['type']}\n{_sse_data(payload)}"
+
+
+def _response_object(*, response_id: str, model: str, created_at: float, message: ResponseOutputMessage | None) -> ResponsesResponse:
+    completed = message is not None
+    return ResponsesResponse(
+        id=response_id,
+        created_at=created_at,
+        status="completed" if completed else "in_progress",
+        completed_at=time.time() if completed else None,
+        model=model,
+        output=[message] if message else [],
+    )
+
+
+@router.post(
+    "/chat/completions",
+    response_model=ChatCompletionResponse,
+    response_model_exclude_none=True,
+    summary="Create a RAG-backed chat completion",
+    description="Supports text-only user/assistant messages, one configured model alias, and optional SSE streaming.",
+    responses={
+        200: {
+            "description": "Chat Completion JSON or SSE stream",
+            "content": {"text/event-stream": {"schema": {"type": "string"}}},
+        },
+        400: {"model": OpenAIErrorResponse, "description": "Invalid or unsupported request"},
+        404: {"model": OpenAIErrorResponse, "description": "Unknown model alias"},
+        500: {"model": OpenAIErrorResponse, "description": "RAG pipeline failure"},
+    },
+)
+async def create_chat_completion(request: ChatCompletionRequest) -> ChatCompletionResponse | StreamingResponse:
+    """Create a text-only Chat Completion using the configured RAG collection."""
+    _validate_model(request.model)
+    messages = _request_messages(request)
+    completion_id = f"chatcmpl-{uuid4().hex}"
+    created = int(time.time())
+
+    if not request.stream:
+        answer = await _answer(messages)
+        return ChatCompletionResponse(
+            id=completion_id,
+            created=created,
+            model=request.model,
+            choices=[ChatCompletionChoice(message=ChatCompletionResponseMessage(content=answer))],
+        )
+
+    async def stream() -> AsyncIterator[str]:
+        yield _sse_data(
+            {
+                "id": completion_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": request.model,
+                "choices": [{"index": 0, "delta": {"role": "assistant", "content": ""}, "finish_reason": None}],
+            }
+        )
+        async for delta in _text_deltas(messages):
+            yield _sse_data(
+                {
+                    "id": completion_id,
+                    "object": "chat.completion.chunk",
+                    "created": created,
+                    "model": request.model,
+                    "choices": [{"index": 0, "delta": {"content": delta}, "finish_reason": None}],
+                }
+            )
+        yield _sse_data(
+            {
+                "id": completion_id,
+                "object": "chat.completion.chunk",
+                "created": created,
+                "model": request.model,
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            }
+        )
+        yield "data: [DONE]\n\n"
+
+    return StreamingResponse(
+        stream(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )
+
+
+@router.post(
+    "/responses",
+    response_model=ResponsesResponse,
+    response_model_exclude_none=True,
+    summary="Create a RAG-backed response",
+    description="Supports string input or text-only user/assistant input messages, one configured model alias, and optional SSE streaming.",
+    responses={
+        200: {
+            "description": "Responses object JSON or SSE stream",
+            "content": {"text/event-stream": {"schema": {"type": "string"}}},
+        },
+        400: {"model": OpenAIErrorResponse, "description": "Invalid or unsupported request"},
+        404: {"model": OpenAIErrorResponse, "description": "Unknown model alias"},
+        500: {"model": OpenAIErrorResponse, "description": "RAG pipeline failure"},
+    },
+)
+async def create_response(request: ResponsesRequest) -> ResponsesResponse | StreamingResponse:
+    """Create a text-only Responses API object using the configured RAG collection."""
+    _validate_model(request.model)
+    messages = _response_messages(request)
+    response_id = f"resp_{uuid4().hex}"
+    message_id = f"msg_{uuid4().hex}"
+    created_at = time.time()
+
+    if not request.stream:
+        answer = await _answer(messages)
+        return _response_object(
+            response_id=response_id,
+            model=request.model,
+            created_at=created_at,
+            message=ResponseOutputMessage(
+                id=message_id,
+                status="completed",
+                content=[ResponseOutputText(text=answer)],
+            ),
+        )
+
+    async def stream() -> AsyncIterator[str]:
+        sequence_number = 0
+        initial_response = _response_object(
+            response_id=response_id,
+            model=request.model,
+            created_at=created_at,
+            message=None,
+        ).model_dump(exclude_none=True)
+        yield _response_sse({"type": "response.created", "response": initial_response, "sequence_number": sequence_number})
+        sequence_number += 1
+        yield _response_sse({"type": "response.in_progress", "response": initial_response, "sequence_number": sequence_number})
+        sequence_number += 1
+
+        in_progress_message = ResponseOutputMessage(id=message_id, status="in_progress", content=[]).model_dump()
+        yield _response_sse(
+            {
+                "type": "response.output_item.added",
+                "output_index": 0,
+                "item": in_progress_message,
+                "sequence_number": sequence_number,
+            }
+        )
+        sequence_number += 1
+        empty_part = ResponseOutputText(text="").model_dump()
+        yield _response_sse(
+            {
+                "type": "response.content_part.added",
+                "item_id": message_id,
+                "output_index": 0,
+                "content_index": 0,
+                "part": empty_part,
+                "sequence_number": sequence_number,
+            }
+        )
+        sequence_number += 1
+
+        text_parts: list[str] = []
+        async for delta in _text_deltas(messages):
+            text_parts.append(delta)
+            yield _response_sse(
+                {
+                    "type": "response.output_text.delta",
+                    "item_id": message_id,
+                    "output_index": 0,
+                    "content_index": 0,
+                    "delta": delta,
+                    "logprobs": [],
+                    "sequence_number": sequence_number,
+                }
+            )
+            sequence_number += 1
+
+        text = "".join(text_parts)
+        completed_part = ResponseOutputText(text=text).model_dump()
+        completed_message = ResponseOutputMessage(
+            id=message_id,
+            status="completed",
+            content=[ResponseOutputText(text=text)],
+        )
+        yield _response_sse(
+            {
+                "type": "response.output_text.done",
+                "item_id": message_id,
+                "output_index": 0,
+                "content_index": 0,
+                "text": text,
+                "logprobs": [],
+                "sequence_number": sequence_number,
+            }
+        )
+        sequence_number += 1
+        yield _response_sse(
+            {
+                "type": "response.content_part.done",
+                "item_id": message_id,
+                "output_index": 0,
+                "content_index": 0,
+                "part": completed_part,
+                "sequence_number": sequence_number,
+            }
+        )
+        sequence_number += 1
+        yield _response_sse(
+            {
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": completed_message.model_dump(),
+                "sequence_number": sequence_number,
+            }
+        )
+        sequence_number += 1
+        completed_response = _response_object(
+            response_id=response_id,
+            model=request.model,
+            created_at=created_at,
+            message=completed_message,
+        ).model_dump(exclude_none=True)
+        yield _response_sse({"type": "response.completed", "response": completed_response, "sequence_number": sequence_number})
+
+    return StreamingResponse(
+        stream(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )

--- a/src/agent/routes/openai_compat.py
+++ b/src/agent/routes/openai_compat.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 
 from fastapi import APIRouter
 from fastapi.responses import StreamingResponse
+from loguru import logger
 
 from agent.data_model.openai_compat import (
     ChatCompletionChoice,
@@ -15,6 +16,7 @@ from agent.data_model.openai_compat import (
     ChatCompletionResponse,
     ChatCompletionResponseMessage,
     OpenAIErrorResponse,
+    ResponseFailure,
     ResponseOutputMessage,
     ResponseOutputText,
     ResponsesRequest,
@@ -90,18 +92,38 @@ async def _answer(messages: list[dict[str, str]]) -> str:
         ) from exc
 
 
+def _event_text_delta(event: dict[str, Any]) -> str | None:
+    if event.get("event") != "on_chat_model_stream" or event.get("metadata", {}).get("langgraph_node") not in _GENERATION_NODES:
+        return None
+    content = event["data"]["chunk"].content
+    if not content:
+        return None
+    if not isinstance(content, str):
+        msg = "The RAG graph returned a non-text stream chunk."
+        raise TypeError(msg)
+    return content
+
+
 async def _text_deltas(messages: list[dict[str, str]]) -> AsyncIterator[str]:
     events = graph.with_config(_graph_config()).astream_events({"messages": messages}, version="v2")
-    async for event in events:
-        if event.get("event") != "on_chat_model_stream" or event.get("metadata", {}).get("langgraph_node") not in _GENERATION_NODES:
-            continue
-        content = event["data"]["chunk"].content
-        if not content:
-            continue
-        if not isinstance(content, str):
-            msg = "The RAG graph returned a non-text stream chunk."
-            raise TypeError(msg)
-        yield content
+    failure_in_flight = False
+    try:
+        async for event in events:
+            content = _event_text_delta(event)
+            if content is not None:
+                yield content
+    except BaseException:
+        failure_in_flight = True
+        raise
+    finally:
+        close = getattr(events, "aclose", None)
+        if close is not None:
+            try:
+                await close()
+            except Exception as exc:
+                if not failure_in_flight:
+                    raise
+                logger.warning("Failed to close upstream RAG event stream: {}", exc)
 
 
 def _sse_data(payload: dict[str, Any]) -> str:
@@ -116,18 +138,50 @@ def _response_object(*, response_id: str, model: str, created_at: float, message
     completed = message is not None
     return ResponsesResponse(
         id=response_id,
+        object="response",
         created_at=created_at,
         status="completed" if completed else "in_progress",
         completed_at=time.time() if completed else None,
+        error=None,
+        incomplete_details=None,
+        instructions=None,
+        metadata={},
         model=model,
         output=[message] if message else [],
+        parallel_tool_calls=False,
+        temperature=None,
+        tool_choice="none",
+        tools=[],
+        top_p=None,
+        usage=None,
+    )
+
+
+def _failed_response(*, response_id: str, model: str, created_at: float, message: ResponseOutputMessage) -> ResponsesResponse:
+    return ResponsesResponse(
+        id=response_id,
+        object="response",
+        created_at=created_at,
+        status="failed",
+        completed_at=None,
+        error=ResponseFailure(code="server_error", message="Internal server error."),
+        incomplete_details=None,
+        instructions=None,
+        metadata={},
+        model=model,
+        output=[message],
+        parallel_tool_calls=False,
+        temperature=None,
+        tool_choice="none",
+        tools=[],
+        top_p=None,
+        usage=None,
     )
 
 
 @router.post(
     "/chat/completions",
     response_model=ChatCompletionResponse,
-    response_model_exclude_none=True,
     summary="Create a RAG-backed chat completion",
     description="Supports text-only user/assistant messages, one configured model alias, and optional SSE streaming.",
     responses={
@@ -151,9 +205,17 @@ async def create_chat_completion(request: ChatCompletionRequest) -> ChatCompleti
         answer = await _answer(messages)
         return ChatCompletionResponse(
             id=completion_id,
+            object="chat.completion",
             created=created,
             model=request.model,
-            choices=[ChatCompletionChoice(message=ChatCompletionResponseMessage(content=answer))],
+            choices=[
+                ChatCompletionChoice(
+                    index=0,
+                    message=ChatCompletionResponseMessage(role="assistant", content=answer, refusal=None),
+                    logprobs=None,
+                    finish_reason="stop",
+                )
+            ],
         )
 
     async def stream() -> AsyncIterator[str]:
@@ -163,26 +225,54 @@ async def create_chat_completion(request: ChatCompletionRequest) -> ChatCompleti
                 "object": "chat.completion.chunk",
                 "created": created,
                 "model": request.model,
-                "choices": [{"index": 0, "delta": {"role": "assistant", "content": ""}, "finish_reason": None}],
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"role": "assistant", "content": "", "refusal": None},
+                        "logprobs": None,
+                        "finish_reason": None,
+                    }
+                ],
             }
         )
-        async for delta in _text_deltas(messages):
+        try:
+            async for delta in _text_deltas(messages):
+                yield _sse_data(
+                    {
+                        "id": completion_id,
+                        "object": "chat.completion.chunk",
+                        "created": created,
+                        "model": request.model,
+                        "choices": [
+                            {
+                                "index": 0,
+                                "delta": {"content": delta},
+                                "logprobs": None,
+                                "finish_reason": None,
+                            }
+                        ],
+                    }
+                )
+        except Exception as exc:
+            logger.error("OpenAI-compatible Chat Completion stream failed: {}", exc)
             yield _sse_data(
                 {
-                    "id": completion_id,
-                    "object": "chat.completion.chunk",
-                    "created": created,
-                    "model": request.model,
-                    "choices": [{"index": 0, "delta": {"content": delta}, "finish_reason": None}],
+                    "error": {
+                        "message": "Internal server error.",
+                        "type": "server_error",
+                        "param": None,
+                        "code": "internal_error",
+                    }
                 }
             )
+            return
         yield _sse_data(
             {
                 "id": completion_id,
                 "object": "chat.completion.chunk",
                 "created": created,
                 "model": request.model,
-                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                "choices": [{"index": 0, "delta": {}, "logprobs": None, "finish_reason": "stop"}],
             }
         )
         yield "data: [DONE]\n\n"
@@ -197,7 +287,6 @@ async def create_chat_completion(request: ChatCompletionRequest) -> ChatCompleti
 @router.post(
     "/responses",
     response_model=ResponsesResponse,
-    response_model_exclude_none=True,
     summary="Create a RAG-backed response",
     description="Supports string input or text-only user/assistant input messages, one configured model alias, and optional SSE streaming.",
     responses={
@@ -226,8 +315,10 @@ async def create_response(request: ResponsesRequest) -> ResponsesResponse | Stre
             created_at=created_at,
             message=ResponseOutputMessage(
                 id=message_id,
+                type="message",
                 status="completed",
-                content=[ResponseOutputText(text=answer)],
+                role="assistant",
+                content=[ResponseOutputText(type="output_text", text=answer, annotations=[])],
             ),
         )
 
@@ -238,13 +329,19 @@ async def create_response(request: ResponsesRequest) -> ResponsesResponse | Stre
             model=request.model,
             created_at=created_at,
             message=None,
-        ).model_dump(exclude_none=True)
+        ).model_dump()
         yield _response_sse({"type": "response.created", "response": initial_response, "sequence_number": sequence_number})
         sequence_number += 1
         yield _response_sse({"type": "response.in_progress", "response": initial_response, "sequence_number": sequence_number})
         sequence_number += 1
 
-        in_progress_message = ResponseOutputMessage(id=message_id, status="in_progress", content=[]).model_dump()
+        in_progress_message = ResponseOutputMessage(
+            id=message_id,
+            type="message",
+            status="in_progress",
+            role="assistant",
+            content=[],
+        ).model_dump()
         yield _response_sse(
             {
                 "type": "response.output_item.added",
@@ -254,7 +351,7 @@ async def create_response(request: ResponsesRequest) -> ResponsesResponse | Stre
             }
         )
         sequence_number += 1
-        empty_part = ResponseOutputText(text="").model_dump()
+        empty_part = ResponseOutputText(type="output_text", text="", annotations=[]).model_dump()
         yield _response_sse(
             {
                 "type": "response.content_part.added",
@@ -268,27 +365,64 @@ async def create_response(request: ResponsesRequest) -> ResponsesResponse | Stre
         sequence_number += 1
 
         text_parts: list[str] = []
-        async for delta in _text_deltas(messages):
-            text_parts.append(delta)
+        try:
+            async for delta in _text_deltas(messages):
+                text_parts.append(delta)
+                yield _response_sse(
+                    {
+                        "type": "response.output_text.delta",
+                        "item_id": message_id,
+                        "output_index": 0,
+                        "content_index": 0,
+                        "delta": delta,
+                        "logprobs": [],
+                        "sequence_number": sequence_number,
+                    }
+                )
+                sequence_number += 1
+        except Exception as exc:
+            logger.error("OpenAI-compatible Responses stream failed: {}", exc)
             yield _response_sse(
                 {
-                    "type": "response.output_text.delta",
-                    "item_id": message_id,
-                    "output_index": 0,
-                    "content_index": 0,
-                    "delta": delta,
-                    "logprobs": [],
+                    "type": "error",
+                    "code": "server_error",
+                    "message": "Internal server error.",
+                    "param": None,
                     "sequence_number": sequence_number,
                 }
             )
             sequence_number += 1
+            partial_text = "".join(text_parts)
+            failed_message = ResponseOutputMessage(
+                id=message_id,
+                type="message",
+                status="incomplete",
+                role="assistant",
+                content=[ResponseOutputText(type="output_text", text=partial_text, annotations=[])],
+            )
+            failed_response = _failed_response(
+                response_id=response_id,
+                model=request.model,
+                created_at=created_at,
+                message=failed_message,
+            ).model_dump()
+            yield _response_sse(
+                {
+                    "type": "response.failed",
+                    "response": failed_response,
+                    "sequence_number": sequence_number,
+                }
+            )
+            return
 
         text = "".join(text_parts)
-        completed_part = ResponseOutputText(text=text).model_dump()
+        completed_part = ResponseOutputText(type="output_text", text=text, annotations=[]).model_dump()
         completed_message = ResponseOutputMessage(
             id=message_id,
+            type="message",
             status="completed",
-            content=[ResponseOutputText(text=text)],
+            role="assistant",
+            content=[ResponseOutputText(type="output_text", text=text, annotations=[])],
         )
         yield _response_sse(
             {
@@ -327,7 +461,7 @@ async def create_response(request: ResponsesRequest) -> ResponsesResponse | Stre
             model=request.model,
             created_at=created_at,
             message=completed_message,
-        ).model_dump(exclude_none=True)
+        ).model_dump()
         yield _response_sse({"type": "response.completed", "response": completed_response, "sequence_number": sequence_number})
 
     return StreamingResponse(

--- a/src/agent/routes/openai_compat.py
+++ b/src/agent/routes/openai_compat.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 from fastapi import APIRouter
 from fastapi.responses import StreamingResponse
 from loguru import logger
+from starlette.types import Send
 
 from agent.data_model.openai_compat import (
     ChatCompletionChoice,
@@ -29,6 +30,26 @@ _GENERATION_NODES = {"response_synthesizer", "response_synthesizer_cohere"}
 
 settings = Config()
 router = APIRouter(prefix="/v1", tags=["OpenAI compatibility"])
+
+
+async def _close_async_iterator(iterator: object) -> None:
+    close = getattr(iterator, "aclose", None)
+    if close is None:
+        return
+    try:
+        await close()
+    except Exception as exc:
+        logger.warning("Failed to close OpenAI-compatible stream iterator: {}", exc)
+
+
+class _ClosingStreamingResponse(StreamingResponse):
+    """Close the response iterator when ASGI sending stops early."""
+
+    async def stream_response(self, send: Send) -> None:
+        try:
+            await super().stream_response(send)
+        finally:
+            await _close_async_iterator(self.body_iterator)
 
 
 class OpenAIAPIError(Exception):
@@ -235,37 +256,41 @@ async def create_chat_completion(request: ChatCompletionRequest) -> ChatCompleti
                 ],
             }
         )
+        deltas = _text_deltas(messages)
         try:
-            async for delta in _text_deltas(messages):
+            try:
+                async for delta in deltas:
+                    yield _sse_data(
+                        {
+                            "id": completion_id,
+                            "object": "chat.completion.chunk",
+                            "created": created,
+                            "model": request.model,
+                            "choices": [
+                                {
+                                    "index": 0,
+                                    "delta": {"content": delta},
+                                    "logprobs": None,
+                                    "finish_reason": None,
+                                }
+                            ],
+                        }
+                    )
+            except Exception as exc:
+                logger.error("OpenAI-compatible Chat Completion stream failed: {}", exc)
                 yield _sse_data(
                     {
-                        "id": completion_id,
-                        "object": "chat.completion.chunk",
-                        "created": created,
-                        "model": request.model,
-                        "choices": [
-                            {
-                                "index": 0,
-                                "delta": {"content": delta},
-                                "logprobs": None,
-                                "finish_reason": None,
-                            }
-                        ],
+                        "error": {
+                            "message": "Internal server error.",
+                            "type": "server_error",
+                            "param": None,
+                            "code": "internal_error",
+                        }
                     }
                 )
-        except Exception as exc:
-            logger.error("OpenAI-compatible Chat Completion stream failed: {}", exc)
-            yield _sse_data(
-                {
-                    "error": {
-                        "message": "Internal server error.",
-                        "type": "server_error",
-                        "param": None,
-                        "code": "internal_error",
-                    }
-                }
-            )
-            return
+                return
+        finally:
+            await _close_async_iterator(deltas)
         yield _sse_data(
             {
                 "id": completion_id,
@@ -277,7 +302,7 @@ async def create_chat_completion(request: ChatCompletionRequest) -> ChatCompleti
         )
         yield "data: [DONE]\n\n"
 
-    return StreamingResponse(
+    return _ClosingStreamingResponse(
         stream(),
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
@@ -365,55 +390,59 @@ async def create_response(request: ResponsesRequest) -> ResponsesResponse | Stre
         sequence_number += 1
 
         text_parts: list[str] = []
+        deltas = _text_deltas(messages)
         try:
-            async for delta in _text_deltas(messages):
-                text_parts.append(delta)
+            try:
+                async for delta in deltas:
+                    text_parts.append(delta)
+                    yield _response_sse(
+                        {
+                            "type": "response.output_text.delta",
+                            "item_id": message_id,
+                            "output_index": 0,
+                            "content_index": 0,
+                            "delta": delta,
+                            "logprobs": [],
+                            "sequence_number": sequence_number,
+                        }
+                    )
+                    sequence_number += 1
+            except Exception as exc:
+                logger.error("OpenAI-compatible Responses stream failed: {}", exc)
                 yield _response_sse(
                     {
-                        "type": "response.output_text.delta",
-                        "item_id": message_id,
-                        "output_index": 0,
-                        "content_index": 0,
-                        "delta": delta,
-                        "logprobs": [],
+                        "type": "error",
+                        "code": "server_error",
+                        "message": "Internal server error.",
+                        "param": None,
                         "sequence_number": sequence_number,
                     }
                 )
                 sequence_number += 1
-        except Exception as exc:
-            logger.error("OpenAI-compatible Responses stream failed: {}", exc)
-            yield _response_sse(
-                {
-                    "type": "error",
-                    "code": "server_error",
-                    "message": "Internal server error.",
-                    "param": None,
-                    "sequence_number": sequence_number,
-                }
-            )
-            sequence_number += 1
-            partial_text = "".join(text_parts)
-            failed_message = ResponseOutputMessage(
-                id=message_id,
-                type="message",
-                status="incomplete",
-                role="assistant",
-                content=[ResponseOutputText(type="output_text", text=partial_text, annotations=[])],
-            )
-            failed_response = _failed_response(
-                response_id=response_id,
-                model=request.model,
-                created_at=created_at,
-                message=failed_message,
-            ).model_dump()
-            yield _response_sse(
-                {
-                    "type": "response.failed",
-                    "response": failed_response,
-                    "sequence_number": sequence_number,
-                }
-            )
-            return
+                partial_text = "".join(text_parts)
+                failed_message = ResponseOutputMessage(
+                    id=message_id,
+                    type="message",
+                    status="incomplete",
+                    role="assistant",
+                    content=[ResponseOutputText(type="output_text", text=partial_text, annotations=[])],
+                )
+                failed_response = _failed_response(
+                    response_id=response_id,
+                    model=request.model,
+                    created_at=created_at,
+                    message=failed_message,
+                ).model_dump()
+                yield _response_sse(
+                    {
+                        "type": "response.failed",
+                        "response": failed_response,
+                        "sequence_number": sequence_number,
+                    }
+                )
+                return
+        finally:
+            await _close_async_iterator(deltas)
 
         text = "".join(text_parts)
         completed_part = ResponseOutputText(type="output_text", text=text, annotations=[]).model_dump()
@@ -464,7 +493,7 @@ async def create_response(request: ResponsesRequest) -> ResponsesResponse | Stre
         ).model_dump()
         yield _response_sse({"type": "response.completed", "response": completed_response, "sequence_number": sequence_number})
 
-    return StreamingResponse(
+    return _ClosingStreamingResponse(
         stream(),
         media_type="text/event-stream",
         headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},

--- a/src/agent/utils/config.py
+++ b/src/agent/utils/config.py
@@ -19,6 +19,7 @@ class Config(BaseSettings):
 
     # Model Configuration
     model_name: str = "gemini/gemini-2.5-flash"
+    openai_compatible_model: str = "rag"
     embedding_provider: str = "google"
     embedding_model_name: str = "gemini-embedding-002"
     embedding_size: int = 768

--- a/template.env
+++ b/template.env
@@ -6,8 +6,12 @@ OPENAI_API_VERSION="2024-02-15-preview"
 COHERE_API_KEY=
 GEMINI_API_KEY=
 
+# OpenAI-compatible API (public alias only; does not select a vector collection)
+OPENAI_COMPATIBLE_MODEL=rag
+
 # Vector Database
 QDRANT_API_KEY="test"
+QDRANT_COLLECTION_NAME=default
 
 # Tracing
 PHOENIX_COLLECTOR_ENDPOINT=http://phoenix:6006

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -1,0 +1,367 @@
+from __future__ import annotations
+
+import importlib
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from openai import OpenAI
+
+pytestmark = pytest.mark.contract
+
+
+class FakeConfiguredGraph:
+    def __init__(self, parent: FakeGraph) -> None:
+        self.parent = parent
+
+    async def ainvoke(self, payload: dict[str, Any]) -> dict[str, Any]:
+        self.parent.payloads.append(payload)
+        if self.parent.fail_invoke:
+            raise RuntimeError("private backend detail")
+        return {"messages": [SimpleNamespace(content="RAG answer")], "documents": []}
+
+    async def astream_events(self, payload: dict[str, Any], *, version: str) -> AsyncIterator[dict[str, Any]]:
+        self.parent.payloads.append(payload)
+        assert version == "v2"
+        yield {
+            "event": "on_chat_model_stream",
+            "metadata": {"langgraph_node": "grader"},
+            "data": {"chunk": SimpleNamespace(content="ignored")},
+        }
+        yield {
+            "event": "on_chat_model_stream",
+            "metadata": {"langgraph_node": "response_synthesizer"},
+            "data": {"chunk": SimpleNamespace(content="RAG ")},
+        }
+        if self.parent.fail_stream:
+            raise RuntimeError("stream failed")
+        yield {
+            "event": "on_chat_model_stream",
+            "metadata": {"langgraph_node": "response_synthesizer"},
+            "data": {"chunk": SimpleNamespace(content="answer")},
+        }
+
+
+class FakeGraph:
+    def __init__(self) -> None:
+        self.configs: list[dict[str, Any]] = []
+        self.payloads: list[dict[str, Any]] = []
+        self.fail_invoke = False
+        self.fail_stream = False
+
+    def with_config(self, config: dict[str, Any]) -> FakeConfiguredGraph:
+        self.configs.append(config)
+        return FakeConfiguredGraph(self)
+
+
+@pytest.fixture
+def fake_graph(app, monkeypatch: pytest.MonkeyPatch) -> FakeGraph:
+    module = importlib.import_module("agent.routes.openai_compat")
+    graph = FakeGraph()
+    monkeypatch.setattr(module, "graph", graph)
+    monkeypatch.setattr(module.settings, "openai_compatible_model", "rag-test")
+    monkeypatch.setattr(module.settings, "qdrant_collection_name", "configured-collection")
+    return graph
+
+
+@pytest.fixture
+def sdk_client(client, fake_graph: FakeGraph) -> OpenAI:
+    return OpenAI(api_key="test-key", base_url="http://testserver/v1", http_client=client)
+
+
+def test_openapi_documents_compatibility_subset(app) -> None:
+    schema = app.openapi()
+
+    for path in ("/v1/chat/completions", "/v1/responses"):
+        operation = schema["paths"][path]["post"]
+        assert "422" not in operation["responses"]
+        assert "text/event-stream" in operation["responses"]["200"]["content"]
+        assert operation["requestBody"]["content"]["application/json"]["schema"]["$ref"]
+
+
+def test_chat_completion_contract(client, fake_graph: FakeGraph) -> None:
+    response = client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "rag-test",
+            "messages": [
+                {"role": "user", "content": "Earlier question"},
+                {"role": "assistant", "content": "Earlier answer"},
+                {"role": "user", "content": "Current question"},
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["object"] == "chat.completion"
+    assert body["model"] == "rag-test"
+    assert body["choices"] == [
+        {
+            "index": 0,
+            "message": {"role": "assistant", "content": "RAG answer"},
+            "finish_reason": "stop",
+        }
+    ]
+    assert "usage" not in body
+    assert fake_graph.configs == [{"metadata": {"collection_name": "configured-collection"}}]
+    assert fake_graph.payloads[0]["messages"][-1] == {"role": "user", "content": "Current question"}
+
+
+def test_chat_completion_stream_contract(client, fake_graph: FakeGraph) -> None:
+    response = client.post(
+        "/v1/chat/completions",
+        json={"model": "rag-test", "messages": [{"role": "user", "content": "Question"}], "stream": True},
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    data_lines = [line.removeprefix("data: ") for line in response.text.splitlines() if line.startswith("data: ")]
+    assert data_lines[-1] == "[DONE]"
+    assert '"finish_reason":"stop"' in data_lines[-2]
+    assert '"content":"RAG "' in data_lines[1]
+    assert '"content":"answer"' in data_lines[2]
+    assert fake_graph.configs == [{"metadata": {"collection_name": "configured-collection"}}]
+
+
+def test_responses_contract_with_string_input(client, fake_graph: FakeGraph) -> None:
+    response = client.post("/v1/responses", json={"model": "rag-test", "input": "Question"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["object"] == "response"
+    assert body["status"] == "completed"
+    assert body["model"] == "rag-test"
+    assert body["output"] == [
+        {
+            "id": body["output"][0]["id"],
+            "type": "message",
+            "status": "completed",
+            "role": "assistant",
+            "content": [{"type": "output_text", "text": "RAG answer", "annotations": []}],
+        }
+    ]
+    assert body["parallel_tool_calls"] is False
+    assert body["tool_choice"] == "none"
+    assert body["tools"] == []
+    assert "usage" not in body
+    assert fake_graph.configs == [{"metadata": {"collection_name": "configured-collection"}}]
+
+
+def test_responses_stream_contract(client, fake_graph: FakeGraph) -> None:
+    response = client.post(
+        "/v1/responses",
+        json={
+            "model": "rag-test",
+            "input": [
+                {"role": "user", "content": "Earlier question"},
+                {"role": "assistant", "content": "Earlier answer"},
+                {"role": "user", "content": "Current question"},
+            ],
+            "stream": True,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    event_names = [line.removeprefix("event: ") for line in response.text.splitlines() if line.startswith("event: ")]
+    assert event_names == [
+        "response.created",
+        "response.in_progress",
+        "response.output_item.added",
+        "response.content_part.added",
+        "response.output_text.delta",
+        "response.output_text.delta",
+        "response.output_text.done",
+        "response.content_part.done",
+        "response.output_item.done",
+        "response.completed",
+    ]
+    assert response.text.endswith("\n\n")
+    assert fake_graph.configs == [{"metadata": {"collection_name": "configured-collection"}}]
+
+
+@pytest.mark.parametrize(
+    ("path", "body", "param"),
+    [
+        (
+            "/v1/chat/completions",
+            {"model": "rag-test", "messages": [{"role": "user", "content": "Question"}], "temperature": 0.2},
+            "temperature",
+        ),
+        ("/v1/responses", {"model": "rag-test", "input": "Question", "tools": []}, "tools"),
+        ("/v1/responses", {"model": "rag-test", "input": "Question", "instructions": "Be terse"}, "instructions"),
+    ],
+)
+def test_unsupported_fields_use_openai_error_envelope(client, fake_graph: FakeGraph, path: str, body: dict[str, Any], param: str) -> None:
+    response = client.post(path, json=body)
+
+    assert response.status_code == 400
+    assert response.json() == {
+        "error": {
+            "message": f"Unsupported field: `{param}`.",
+            "type": "invalid_request_error",
+            "param": param,
+            "code": "unsupported_parameter",
+        }
+    }
+    assert fake_graph.configs == []
+
+
+def test_multimodal_input_is_rejected(client, fake_graph: FakeGraph) -> None:
+    response = client.post(
+        "/v1/responses",
+        json={
+            "model": "rag-test",
+            "input": [{"role": "user", "content": [{"type": "input_image", "image_url": "https://example.test/image"}]}],
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["type"] == "invalid_request_error"
+    assert response.json()["error"]["code"] == "invalid_value"
+    assert fake_graph.configs == []
+
+
+def test_model_alias_is_validated_without_selecting_collection(client, fake_graph: FakeGraph) -> None:
+    response = client.post(
+        "/v1/chat/completions",
+        json={"model": "another-collection", "messages": [{"role": "user", "content": "Question"}]},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "error": {
+            "message": "The model `another-collection` does not exist or is not available.",
+            "type": "invalid_request_error",
+            "param": "model",
+            "code": "model_not_found",
+        }
+    }
+    assert fake_graph.configs == []
+
+
+def test_final_message_must_be_user(client, fake_graph: FakeGraph) -> None:
+    response = client.post(
+        "/v1/chat/completions",
+        json={"model": "rag-test", "messages": [{"role": "assistant", "content": "No question"}]},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["error"]["code"] == "invalid_value"
+    assert fake_graph.configs == []
+
+
+def test_openai_internal_error_does_not_leak_details(client, fake_graph: FakeGraph) -> None:
+    fake_graph.fail_invoke = True
+    response = client.post(
+        "/v1/responses",
+        json={"model": "rag-test", "input": "Question"},
+    )
+
+    assert response.status_code == 500
+    assert response.json() == {
+        "error": {
+            "message": "Internal server error.",
+            "type": "server_error",
+            "param": None,
+            "code": "internal_error",
+        }
+    }
+
+
+def test_unknown_v1_route_uses_openai_error_envelope(client, fake_graph: FakeGraph) -> None:
+    response = client.get("/v1/not-implemented")
+
+    assert response.status_code == 404
+    assert response.json() == {
+        "error": {
+            "message": "Not Found",
+            "type": "invalid_request_error",
+            "param": None,
+            "code": "not_found",
+        }
+    }
+
+
+def test_non_openai_validation_error_is_unchanged(client, fake_graph: FakeGraph) -> None:
+    response = client.post("/semantic/search", json={})
+
+    assert response.status_code == 422
+    assert "detail" in response.json()
+
+
+def test_installed_sdk_parses_chat_non_streaming_and_streaming(sdk_client: OpenAI) -> None:
+    completion = sdk_client.chat.completions.create(
+        model="rag-test",
+        messages=[{"role": "user", "content": "Question"}],
+    )
+    assert completion.object == "chat.completion"
+    assert completion.choices[0].message.content == "RAG answer"
+    assert completion.usage is None
+
+    chunks = list(
+        sdk_client.chat.completions.create(
+            model="rag-test",
+            messages=[{"role": "user", "content": "Question"}],
+            stream=True,
+        )
+    )
+    assert "".join(chunk.choices[0].delta.content or "" for chunk in chunks) == "RAG answer"
+    assert chunks[-1].choices[0].finish_reason == "stop"
+
+
+def test_installed_sdk_parses_responses_non_streaming_and_streaming(sdk_client: OpenAI) -> None:
+    response = sdk_client.responses.create(model="rag-test", input="Question")
+    assert response.object == "response"
+    assert response.output_text == "RAG answer"
+    assert response.usage is None
+
+    raw_events = list(sdk_client.responses.create(model="rag-test", input="Question", stream=True))
+    assert "".join(event.delta for event in raw_events if event.type == "response.output_text.delta") == "RAG answer"
+    assert raw_events[-1].type == "response.completed"
+    assert raw_events[-1].response.output_text == "RAG answer"
+
+    with sdk_client.responses.stream(model="rag-test", input="Question") as stream:
+        deltas = [event.delta for event in stream if event.type == "response.output_text.delta"]
+        final_response = stream.get_final_response()
+    assert "".join(deltas) == "RAG answer"
+    assert final_response.output_text == "RAG answer"
+
+
+@pytest.mark.anyio
+async def test_midstream_failure_has_no_chat_done_marker(app, fake_graph: FakeGraph) -> None:
+    module = importlib.import_module("agent.routes.openai_compat")
+    schema_module = importlib.import_module("agent.data_model.openai_compat")
+    fake_graph.fail_stream = True
+    response = await module.create_chat_completion(
+        schema_module.ChatCompletionRequest(
+            model="rag-test",
+            messages=[{"role": "user", "content": "Question"}],
+            stream=True,
+        )
+    )
+
+    chunks: list[str] = []
+    with pytest.raises(RuntimeError, match="stream failed"):
+        async for chunk in response.body_iterator:
+            chunks.append(chunk)
+    assert "[DONE]" not in "".join(chunks)
+    assert '"finish_reason":"stop"' not in "".join(chunks)
+
+
+@pytest.mark.anyio
+async def test_midstream_failure_has_no_responses_completion_event(app, fake_graph: FakeGraph) -> None:
+    module = importlib.import_module("agent.routes.openai_compat")
+    schema_module = importlib.import_module("agent.data_model.openai_compat")
+    fake_graph.fail_stream = True
+    response = await module.create_response(
+        schema_module.ResponsesRequest(model="rag-test", input="Question", stream=True)
+    )
+
+    chunks: list[str] = []
+    with pytest.raises(RuntimeError, match="stream failed"):
+        async for chunk in response.body_iterator:
+            chunks.append(chunk)
+    assert "response.completed" not in "".join(chunks)

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pytest
 from openai import APIError, OpenAI
+from starlette.requests import ClientDisconnect
 
 pytestmark = pytest.mark.contract
 
@@ -73,6 +74,45 @@ def fake_graph(app, monkeypatch: pytest.MonkeyPatch) -> FakeGraph:
 @pytest.fixture
 def sdk_client(client, fake_graph: FakeGraph) -> OpenAI:
     return OpenAI(api_key="test-key", base_url="http://testserver/v1", http_client=client)
+
+
+async def _request_with_send_failure(app: Any, path: str, payload: dict[str, Any], failure_marker: str) -> list[str]:
+    request_body = json.dumps(payload).encode()
+    request_received = False
+    sent_bodies: list[str] = []
+
+    async def receive() -> dict[str, Any]:
+        nonlocal request_received
+        if not request_received:
+            request_received = True
+            return {"type": "http.request", "body": request_body, "more_body": False}
+        return {"type": "http.disconnect"}
+
+    async def send(message: dict[str, Any]) -> None:
+        if message["type"] != "http.response.body":
+            return
+        body = message.get("body", b"").decode()
+        if failure_marker in body:
+            raise OSError("client disconnected")
+        sent_bodies.append(body)
+
+    scope = {
+        "type": "http",
+        "asgi": {"version": "3.0", "spec_version": "2.4"},
+        "http_version": "1.1",
+        "method": "POST",
+        "scheme": "http",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "root_path": "",
+        "headers": [(b"host", b"testserver"), (b"content-type", b"application/json")],
+        "client": ("testclient", 50000),
+        "server": ("testserver", 80),
+    }
+    with pytest.raises(ClientDisconnect):
+        await app(scope, receive, send)
+    return sent_bodies
 
 
 def test_openapi_documents_compatibility_subset(app) -> None:
@@ -453,3 +493,41 @@ def test_responses_stream_failure_uses_official_sdk_events(client, sdk_client: O
             stream.get_final_response()
     assert stream_events[-1].type == "response.failed"
     assert fake_graph.stream_closed is True
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("path", "payload", "failure_marker", "forbidden_markers"),
+    [
+        (
+            "/v1/chat/completions",
+            {
+                "model": "rag-test",
+                "messages": [{"role": "user", "content": "Question"}],
+                "stream": True,
+            },
+            '"content":"RAG "',
+            ('"error"', '"finish_reason":"stop"', "[DONE]"),
+        ),
+        (
+            "/v1/responses",
+            {"model": "rag-test", "input": "Question", "stream": True},
+            '"type":"response.output_text.delta"',
+            ('"type":"error"', '"type":"response.failed"', '"type":"response.completed"'),
+        ),
+    ],
+)
+async def test_asgi_send_failure_closes_upstream_without_terminal_events(
+    app,
+    fake_graph: FakeGraph,
+    path: str,
+    payload: dict[str, Any],
+    failure_marker: str,
+    forbidden_markers: tuple[str, ...],
+) -> None:
+    sent_bodies = await _request_with_send_failure(app, path, payload, failure_marker)
+
+    assert fake_graph.stream_closed is True
+    body = "".join(sent_bodies)
+    assert failure_marker not in body
+    assert all(marker not in body for marker in forbidden_markers)

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import importlib
+import json
 from collections.abc import AsyncIterator
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
-from openai import OpenAI
+from openai import APIError, OpenAI
 
 pytestmark = pytest.mark.contract
 
@@ -24,23 +25,26 @@ class FakeConfiguredGraph:
     async def astream_events(self, payload: dict[str, Any], *, version: str) -> AsyncIterator[dict[str, Any]]:
         self.parent.payloads.append(payload)
         assert version == "v2"
-        yield {
-            "event": "on_chat_model_stream",
-            "metadata": {"langgraph_node": "grader"},
-            "data": {"chunk": SimpleNamespace(content="ignored")},
-        }
-        yield {
-            "event": "on_chat_model_stream",
-            "metadata": {"langgraph_node": "response_synthesizer"},
-            "data": {"chunk": SimpleNamespace(content="RAG ")},
-        }
-        if self.parent.fail_stream:
-            raise RuntimeError("stream failed")
-        yield {
-            "event": "on_chat_model_stream",
-            "metadata": {"langgraph_node": "response_synthesizer"},
-            "data": {"chunk": SimpleNamespace(content="answer")},
-        }
+        try:
+            yield {
+                "event": "on_chat_model_stream",
+                "metadata": {"langgraph_node": "grader"},
+                "data": {"chunk": SimpleNamespace(content="ignored")},
+            }
+            yield {
+                "event": "on_chat_model_stream",
+                "metadata": {"langgraph_node": "response_synthesizer"},
+                "data": {"chunk": SimpleNamespace(content="RAG ")},
+            }
+            if self.parent.fail_stream:
+                raise RuntimeError("stream failed")
+            yield {
+                "event": "on_chat_model_stream",
+                "metadata": {"langgraph_node": "response_synthesizer"},
+                "data": {"chunk": SimpleNamespace(content="answer")},
+            }
+        finally:
+            self.parent.stream_closed = True
 
 
 class FakeGraph:
@@ -49,6 +53,7 @@ class FakeGraph:
         self.payloads: list[dict[str, Any]] = []
         self.fail_invoke = False
         self.fail_stream = False
+        self.stream_closed = False
 
     def with_config(self, config: dict[str, Any]) -> FakeConfiguredGraph:
         self.configs.append(config)
@@ -79,6 +84,24 @@ def test_openapi_documents_compatibility_subset(app) -> None:
         assert "text/event-stream" in operation["responses"]["200"]["content"]
         assert operation["requestBody"]["content"]["application/json"]["schema"]["$ref"]
 
+    components = schema["components"]["schemas"]
+    assert set(components["ChatCompletionChoice"]["required"]) == {"index", "message", "logprobs", "finish_reason"}
+    assert set(components["ChatCompletionResponseMessage"]["required"]) == {"role", "content", "refusal"}
+    assert {
+        "object",
+        "completed_at",
+        "error",
+        "incomplete_details",
+        "instructions",
+        "metadata",
+        "parallel_tool_calls",
+        "temperature",
+        "tool_choice",
+        "tools",
+        "top_p",
+        "usage",
+    } <= set(components["ResponsesResponse"]["required"])
+
 
 def test_chat_completion_contract(client, fake_graph: FakeGraph) -> None:
     response = client.post(
@@ -100,7 +123,8 @@ def test_chat_completion_contract(client, fake_graph: FakeGraph) -> None:
     assert body["choices"] == [
         {
             "index": 0,
-            "message": {"role": "assistant", "content": "RAG answer"},
+            "message": {"role": "assistant", "content": "RAG answer", "refusal": None},
+            "logprobs": None,
             "finish_reason": "stop",
         }
     ]
@@ -119,9 +143,12 @@ def test_chat_completion_stream_contract(client, fake_graph: FakeGraph) -> None:
     assert response.headers["content-type"].startswith("text/event-stream")
     data_lines = [line.removeprefix("data: ") for line in response.text.splitlines() if line.startswith("data: ")]
     assert data_lines[-1] == "[DONE]"
-    assert '"finish_reason":"stop"' in data_lines[-2]
-    assert '"content":"RAG "' in data_lines[1]
-    assert '"content":"answer"' in data_lines[2]
+    chunks = [json.loads(line) for line in data_lines[:-1]]
+    assert chunks[0]["choices"][0]["delta"] == {"role": "assistant", "content": "", "refusal": None}
+    assert all(chunk["choices"][0]["logprobs"] is None for chunk in chunks)
+    assert chunks[-1]["choices"][0]["finish_reason"] == "stop"
+    assert chunks[1]["choices"][0]["delta"]["content"] == "RAG "
+    assert chunks[2]["choices"][0]["delta"]["content"] == "answer"
     assert fake_graph.configs == [{"metadata": {"collection_name": "configured-collection"}}]
 
 
@@ -142,10 +169,21 @@ def test_responses_contract_with_string_input(client, fake_graph: FakeGraph) -> 
             "content": [{"type": "output_text", "text": "RAG answer", "annotations": []}],
         }
     ]
-    assert body["parallel_tool_calls"] is False
-    assert body["tool_choice"] == "none"
-    assert body["tools"] == []
-    assert "usage" not in body
+    required_fields = {
+        "error": None,
+        "incomplete_details": None,
+        "instructions": None,
+        "metadata": {},
+        "parallel_tool_calls": False,
+        "temperature": None,
+        "tool_choice": "none",
+        "tools": [],
+        "top_p": None,
+        "usage": None,
+    }
+    assert body["completed_at"] is not None
+    for field, value in required_fields.items():
+        assert body[field] == value
     assert fake_graph.configs == [{"metadata": {"collection_name": "configured-collection"}}]
 
 
@@ -224,6 +262,27 @@ def test_multimodal_input_is_rejected(client, fake_graph: FakeGraph) -> None:
     assert fake_graph.configs == []
 
 
+@pytest.mark.parametrize("stream", ["true", 1, None])
+@pytest.mark.parametrize(
+    ("path", "body"),
+    [
+        ("/v1/chat/completions", {"model": "rag-test", "messages": [{"role": "user", "content": "Question"}]}),
+        ("/v1/responses", {"model": "rag-test", "input": "Question"}),
+    ],
+)
+def test_stream_requires_a_boolean(client, fake_graph: FakeGraph, path: str, body: dict[str, Any], stream: Any) -> None:
+    response = client.post(path, json={**body, "stream": stream})
+
+    assert response.status_code == 400
+    assert response.json()["error"] == {
+        "message": "Input should be a valid boolean",
+        "type": "invalid_request_error",
+        "param": "stream",
+        "code": "invalid_value",
+    }
+    assert fake_graph.configs == []
+
+
 def test_model_alias_is_validated_without_selecting_collection(client, fake_graph: FakeGraph) -> None:
     response = client.post(
         "/v1/chat/completions",
@@ -271,8 +330,9 @@ def test_openai_internal_error_does_not_leak_details(client, fake_graph: FakeGra
     }
 
 
-def test_unknown_v1_route_uses_openai_error_envelope(client, fake_graph: FakeGraph) -> None:
-    response = client.get("/v1/not-implemented")
+@pytest.mark.parametrize("path", ["/v1", "/v1/not-implemented"])
+def test_unknown_v1_route_uses_openai_error_envelope(client, fake_graph: FakeGraph, path: str) -> None:
+    response = client.get(path)
 
     assert response.status_code == 404
     assert response.json() == {
@@ -330,38 +390,66 @@ def test_installed_sdk_parses_responses_non_streaming_and_streaming(sdk_client: 
     assert final_response.output_text == "RAG answer"
 
 
-@pytest.mark.anyio
-async def test_midstream_failure_has_no_chat_done_marker(app, fake_graph: FakeGraph) -> None:
-    module = importlib.import_module("agent.routes.openai_compat")
-    schema_module = importlib.import_module("agent.data_model.openai_compat")
+def test_chat_stream_failure_uses_sdk_error_contract(client, sdk_client: OpenAI, fake_graph: FakeGraph) -> None:
     fake_graph.fail_stream = True
-    response = await module.create_chat_completion(
-        schema_module.ChatCompletionRequest(
-            model="rag-test",
-            messages=[{"role": "user", "content": "Question"}],
-            stream=True,
+    request = {
+        "model": "rag-test",
+        "messages": [{"role": "user", "content": "Question"}],
+        "stream": True,
+    }
+
+    response = client.post("/v1/chat/completions", json=request)
+    data = [line.removeprefix("data: ") for line in response.text.splitlines() if line.startswith("data: ")]
+    assert json.loads(data[-1]) == {
+        "error": {
+            "message": "Internal server error.",
+            "type": "server_error",
+            "param": None,
+            "code": "internal_error",
+        }
+    }
+    assert "[DONE]" not in data
+    assert '"finish_reason":"stop"' not in response.text
+
+    with pytest.raises(APIError, match="Internal server error"):
+        list(
+            sdk_client.chat.completions.create(
+                model="rag-test",
+                messages=[{"role": "user", "content": "Question"}],
+                stream=True,
+            )
         )
-    )
-
-    chunks: list[str] = []
-    with pytest.raises(RuntimeError, match="stream failed"):
-        async for chunk in response.body_iterator:
-            chunks.append(chunk)
-    assert "[DONE]" not in "".join(chunks)
-    assert '"finish_reason":"stop"' not in "".join(chunks)
+    assert fake_graph.stream_closed is True
 
 
-@pytest.mark.anyio
-async def test_midstream_failure_has_no_responses_completion_event(app, fake_graph: FakeGraph) -> None:
-    module = importlib.import_module("agent.routes.openai_compat")
-    schema_module = importlib.import_module("agent.data_model.openai_compat")
+def test_responses_stream_failure_uses_official_sdk_events(client, sdk_client: OpenAI, fake_graph: FakeGraph) -> None:
     fake_graph.fail_stream = True
-    response = await module.create_response(
-        schema_module.ResponsesRequest(model="rag-test", input="Question", stream=True)
-    )
+    response = client.post("/v1/responses", json={"model": "rag-test", "input": "Question", "stream": True})
+    event_names = [line.removeprefix("event: ") for line in response.text.splitlines() if line.startswith("event: ")]
+    payloads = [json.loads(line.removeprefix("data: ")) for line in response.text.splitlines() if line.startswith("data: ")]
 
-    chunks: list[str] = []
-    with pytest.raises(RuntimeError, match="stream failed"):
-        async for chunk in response.body_iterator:
-            chunks.append(chunk)
-    assert "response.completed" not in "".join(chunks)
+    assert event_names[-2:] == ["error", "response.failed"]
+    assert "response.completed" not in event_names
+    assert payloads[-2] == {
+        "type": "error",
+        "code": "server_error",
+        "message": "Internal server error.",
+        "param": None,
+        "sequence_number": payloads[-2]["sequence_number"],
+    }
+    assert payloads[-1]["type"] == "response.failed"
+    assert payloads[-1]["response"]["status"] == "failed"
+    assert payloads[-1]["response"]["error"] == {"code": "server_error", "message": "Internal server error."}
+
+    events = list(sdk_client.responses.create(model="rag-test", input="Question", stream=True))
+    assert [event.type for event in events[-2:]] == ["error", "response.failed"]
+    assert events[-2].code == "server_error"
+    assert events[-1].response.status == "failed"
+    assert events[-1].response.error.code == "server_error"
+
+    with sdk_client.responses.stream(model="rag-test", input="Question") as stream:
+        stream_events = list(stream)
+        with pytest.raises(RuntimeError, match="Didn't receive a `response.completed` event"):
+            stream.get_final_response()
+    assert stream_events[-1].type == "response.failed"
+    assert fake_graph.stream_closed is True


### PR DESCRIPTION
## Summary

- add OpenAI-compatible `POST /v1/chat/completions` and `POST /v1/responses` endpoints
- support SDK-parseable non-streaming and SSE streaming responses for both APIs
- expose an explicit text-only RAG compatibility subset and reject unsupported fields instead of silently ignoring them
- keep the public model alias separate from the server-controlled Qdrant collection
- return OpenAI-style validation, model, routing, and streaming failure envelopes under `/v1`
- guarantee upstream LangGraph stream cleanup on errors, cancellation, and client disconnect

## Supported subset

### Chat Completions

- text-only `user` and `assistant` messages
- `model`
- strict boolean `stream`
- non-streaming completion objects and streaming chunks ending with `[DONE]`

### Responses

- string or text-message `input`
- `model`
- strict boolean `stream`
- non-streaming response objects and standard Responses streaming events

Unsupported features such as tools, multimodal input, structured output, previous-response state, unsupported roles, and generation controls return explicit errors.

## Verification

- OpenAI Python SDK 2.48.0 parses Chat and Responses success/failure contracts in both streaming modes
- realistic ASGI disconnect/cancellation probes confirm outer and upstream iterators close without false terminal events
- targeted OpenAI contracts — 27 passed
- full non-network suite — 83 passed, 4 deselected
- Prek, Ruff, formatting, and ty — passed with no configured errors
- `compileall`, runtime Uvicorn smoke test, and `git diff --check` — passed

## Caveats

- authentication is not introduced by this PR
- citations remain available through the existing `/rag` API
- usage is omitted because reliable token counts are unavailable

## Merge order

This PR and the VDB lifespan follow-up both touch `src/agent/api.py`. Merge the lifespan PR first, then rebase this branch onto `main` before merging.
