### PR TITLE
build(docker): migrate to Docker Hardened Images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,5 +4,6 @@ logs/
 data/
 ConvAgentBruno/
 .venv/
+.git
 .github/
 .vscode/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,6 +44,8 @@ jobs:
           exit 1
 
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Verify DHI credentials are configured
         env:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,49 @@
+name: Docker images
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to Docker Hardened Images
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: echo "$DOCKER_PASSWORD" | docker login dhi.io --username "$DOCKER_USERNAME" --password-stdin
+
+      - name: Build backend image
+        run: docker build --pull --tag conversational-agent-backend:test .
+
+      - name: Build frontend image
+        run: docker build --pull --file Dockerfile.frontend --tag conversational-agent-frontend:test .
+
+      - name: Verify runtime users and Python environments
+        run: |
+          test "$(docker image inspect --format '{{.Config.User}}' conversational-agent-backend:test)" = "nonroot"
+          test "$(docker image inspect --format '{{.Config.User}}' conversational-agent-frontend:test)" = "nonroot"
+          docker run --rm --entrypoint /app/.venv/bin/python conversational-agent-backend:test \
+            -c 'import importlib.util; import fastembed, onnxruntime, pypdfium2, uvicorn; assert importlib.util.find_spec("agent.api") is not None'
+          docker run --rm --entrypoint /app/.venv/bin/python conversational-agent-frontend:test \
+            -c 'import httpx, streamlit; import client'
+
+      - name: Smoke test frontend startup
+        run: |
+          container_id=$(docker run --detach --publish 127.0.0.1:8501:8501 conversational-agent-frontend:test)
+          trap 'docker logs "$container_id"; docker rm --force "$container_id"' EXIT
+          ready=false
+          for _ in $(seq 1 30); do
+            if curl --fail --silent --show-error http://127.0.0.1:8501/ >/dev/null; then
+              ready=true
+              break
+            fi
+            sleep 1
+          done
+          test "$ready" = true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -29,10 +29,20 @@ permissions:
 jobs:
   build:
     name: Build and smoke test DHI images
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     steps:
+      - name: Reject fork pull requests before validation
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "::error title=DHI validation required::Fork pull requests cannot receive dhi.io credentials. Push this commit to a trusted same-repository branch for validation."
+          {
+            echo "### Docker Hardened Images validation is required"
+            echo
+            echo "This fork pull request cannot receive dhi.io credentials, so validation cannot run here. A maintainer must push the commit to a trusted branch in this repository."
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Verify DHI credentials are configured
@@ -149,17 +159,3 @@ jobs:
             sleep 1
           done
           test "$ready" = true
-
-  fork-notice:
-    name: DHI validation not run (fork PR)
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
-    runs-on: ubuntu-latest
-    steps:
-      - name: Explain trusted validation requirement
-        run: |
-          echo "::notice title=DHI validation not run::Fork pull requests do not receive dhi.io credentials. No Docker image was built or validated. A maintainer must run the commit from a trusted repository branch."
-          {
-            echo "### Docker Hardened Images validation was not run"
-            echo
-            echo "This is a fork pull request, so no dhi.io credentials were provided and no image was built. A maintainer must validate the commit from a trusted repository branch."
-          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,16 +2,53 @@ name: Docker images
 
 on:
   push:
-    branches: [main]
+    paths:
+      - ".dockerignore"
+      - ".github/workflows/docker.yml"
+      - "Dockerfile*"
+      - "README.md"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "src/**"
+      - "frontend/**"
   pull_request:
     branches: [main]
+    paths:
+      - ".dockerignore"
+      - ".github/workflows/docker.yml"
+      - "Dockerfile*"
+      - "README.md"
+      - "pyproject.toml"
+      - "uv.lock"
+      - "src/**"
+      - "frontend/**"
+
+permissions:
+  contents: read
 
 jobs:
   build:
+    name: Build and smoke test DHI images
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Verify DHI credentials are configured
+        env:
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        run: |
+          if [[ -z "$DOCKER_USERNAME" || -z "$DOCKER_PASSWORD" ]]; then
+            echo "::error title=DHI credentials unavailable::Configure DOCKER_USERNAME and DOCKER_PASSWORD as Actions secrets. Dependabot PRs require Dependabot secrets with the same names."
+            {
+              echo "### Docker image validation could not start"
+              echo
+              echo "The required dhi.io credentials are unavailable. Configure DOCKER_USERNAME and DOCKER_PASSWORD as repository Actions secrets and, for Dependabot PRs, as Dependabot secrets with the same names."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
 
       - name: Log in to Docker Hardened Images
         env:
@@ -30,20 +67,99 @@ jobs:
           test "$(docker image inspect --format '{{.Config.User}}' conversational-agent-backend:test)" = "nonroot"
           test "$(docker image inspect --format '{{.Config.User}}' conversational-agent-frontend:test)" = "nonroot"
           docker run --rm --entrypoint /app/.venv/bin/python conversational-agent-backend:test \
-            -c 'import importlib.util; import fastembed, onnxruntime, pypdfium2, uvicorn; assert importlib.util.find_spec("agent.api") is not None'
+            -c 'import fastembed, onnxruntime, pypdfium2, uvicorn'
           docker run --rm --entrypoint /app/.venv/bin/python conversational-agent-frontend:test \
             -c 'import httpx, streamlit; import client'
 
+      - name: Smoke test backend startup
+        run: |
+          network_name="dhi-smoke-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          backend_name="dhi-backend-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          qdrant_name="dhi-qdrant-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+          cleanup() {
+            result=$?
+            if [[ $result -ne 0 ]]; then
+              echo "::group::Backend logs"
+              docker logs "$backend_name" 2>&1 || true
+              echo "::endgroup::"
+              echo "::group::Qdrant logs"
+              docker logs "$qdrant_name" 2>&1 || true
+              echo "::endgroup::"
+            fi
+            docker rm --force "$backend_name" "$qdrant_name" >/dev/null 2>&1 || true
+            docker network rm "$network_name" >/dev/null 2>&1 || true
+            exit "$result"
+          }
+          trap cleanup EXIT
+
+          docker network create "$network_name"
+          docker run --detach --name "$qdrant_name" --network "$network_name" --network-alias qdrant \
+            --publish 127.0.0.1::6333 \
+            qdrant/qdrant:v1.18.3@sha256:0bd98fa7977f1e75694779359ca4e212822e5a71334e28421182f72f209d5286
+
+          qdrant_port=$(docker port "$qdrant_name" 6333/tcp | awk -F: '{print $NF}')
+          qdrant_ready=false
+          for _ in $(seq 1 60); do
+            if curl --fail --silent --show-error "http://127.0.0.1:${qdrant_port}/readyz" >/dev/null; then
+              qdrant_ready=true
+              break
+            fi
+            sleep 1
+          done
+          test "$qdrant_ready" = true
+
+          docker run --detach --name "$backend_name" --network "$network_name" \
+            --publish 127.0.0.1::8001 \
+            --env QDRANT_URL=http://qdrant \
+            --env PHOENIX_COLLECTOR_ENDPOINT=http://127.0.0.1:4318/v1/traces \
+            conversational-agent-backend:test
+
+          backend_port=$(docker port "$backend_name" 8001/tcp | awk -F: '{print $NF}')
+          backend_ready=false
+          for _ in $(seq 1 60); do
+            if curl --fail --silent --show-error "http://127.0.0.1:${backend_port}/" | grep --quiet "Welcome to the RAG Backend"; then
+              backend_ready=true
+              break
+            fi
+            sleep 1
+          done
+          test "$backend_ready" = true
+
       - name: Smoke test frontend startup
         run: |
-          container_id=$(docker run --detach --publish 127.0.0.1:8501:8501 conversational-agent-frontend:test)
-          trap 'docker logs "$container_id"; docker rm --force "$container_id"' EXIT
+          container_id=$(docker run --detach --publish 127.0.0.1::8501 conversational-agent-frontend:test)
+          cleanup() {
+            result=$?
+            if [[ $result -ne 0 ]]; then
+              docker logs "$container_id" 2>&1 || true
+            fi
+            docker rm --force "$container_id" >/dev/null 2>&1 || true
+            exit "$result"
+          }
+          trap cleanup EXIT
+
+          frontend_port=$(docker port "$container_id" 8501/tcp | awk -F: '{print $NF}')
           ready=false
           for _ in $(seq 1 30); do
-            if curl --fail --silent --show-error http://127.0.0.1:8501/ >/dev/null; then
+            if curl --fail --silent --show-error "http://127.0.0.1:${frontend_port}/" >/dev/null; then
               ready=true
               break
             fi
             sleep 1
           done
           test "$ready" = true
+
+  fork-notice:
+    name: DHI validation not run (fork PR)
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain trusted validation requirement
+        run: |
+          echo "::notice title=DHI validation not run::Fork pull requests do not receive dhi.io credentials. No Docker image was built or validated. A maintainer must run the commit from a trusted repository branch."
+          {
+            echo "### Docker Hardened Images validation was not run"
+            echo
+            echo "This is a fork pull request, so no dhi.io credentials were provided and no image was built. A maintainer must validate the commit from a trusted repository branch."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,40 @@
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
+# syntax=docker/dockerfile:1
 
-# Enable bytecode compilation (faster startup)
-ENV UV_COMPILE_BYTECODE=1
+FROM dhi.io/uv:0.12.5-debian13@sha256:c804efbe6ad0091c93fabafd6ee0af4273a2e3e436b8bb86c7e45c9a58fd93d3 AS uv
 
-# Copy from cache instead of linking (required for Docker layer caching)
-ENV UV_LINK_MODE=copy
+FROM dhi.io/python:3.13.15-debian13-dev@sha256:2167b6b86500f8e40f0e09fa1453a4f62cc7bbd4af2398907ade6af4302d7b83 AS builder
 
-# copy python installation files.
-COPY ./pyproject.toml ./pyproject.toml
-COPY ./README.md ./README.md
-COPY ./uv.lock ./uv.lock
+COPY --from=uv /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/
 
-# installing python dependencies
-RUN uv sync --frozen --no-install-project
+ENV UV_PYTHON_DOWNLOADS=0 \
+    UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy
 
-COPY ./src /src
+WORKDIR /app
 
-RUN uv sync --frozen
+COPY pyproject.toml uv.lock README.md ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-install-project --no-editable
 
-ENTRYPOINT ["uv", "run", "uvicorn", "src.agent.api:app", "--host", "0.0.0.0", "--port", "8001"]
+COPY src ./src
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-editable \
+    && mkdir /app/work
+
+FROM dhi.io/python:3.13.15-debian13@sha256:c8f52628204884bf35cdff4d57eb3d58fd92fdadd3cc1f47eaa1c4efcead9090
+
+ENV UV_PYTHON_DOWNLOADS=0 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PATH="/app/.venv/bin:$PATH" \
+    HOME=/app/work
+
+COPY --from=builder --chown=nonroot:nonroot /app/.venv /app/.venv
+COPY --from=builder --chown=nonroot:nonroot /app/work /app/work
+
+USER nonroot
+WORKDIR /app/work
+
+EXPOSE 8001
+
+ENTRYPOINT ["/app/.venv/bin/uvicorn", "agent.api:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1
+# syntax=docker/dockerfile:1@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
 
 FROM dhi.io/uv:0.12.5-debian13@sha256:c804efbe6ad0091c93fabafd6ee0af4273a2e3e436b8bb86c7e45c9a58fd93d3 AS uv
 

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,18 +1,35 @@
-FROM ghcr.io/astral-sh/uv:python3.13-bookworm
+# syntax=docker/dockerfile:1
 
-# Set working directory
+FROM dhi.io/uv:0.12.5-debian13@sha256:c804efbe6ad0091c93fabafd6ee0af4273a2e3e436b8bb86c7e45c9a58fd93d3 AS uv
+
+FROM dhi.io/python:3.13.15-debian13-dev@sha256:2167b6b86500f8e40f0e09fa1453a4f62cc7bbd4af2398907ade6af4302d7b83 AS builder
+
+COPY --from=uv /usr/local/bin/uv /usr/local/bin/uvx /usr/local/bin/
+
+ENV UV_PYTHON_DOWNLOADS=0 \
+    UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy
+
 WORKDIR /app
 
-# Copy dependency files first for caching
 COPY frontend/pyproject.toml frontend/uv.lock ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-install-project
 
-# Install dependencies
-RUN uv sync --frozen --no-dev
+FROM dhi.io/python:3.13.15-debian13@sha256:c8f52628204884bf35cdff4d57eb3d58fd92fdadd3cc1f47eaa1c4efcead9090
 
-# Copy the rest of the frontend code
-COPY frontend/ .
+ENV UV_PYTHON_DOWNLOADS=0 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PATH="/app/.venv/bin:$PATH" \
+    HOME=/tmp
 
-# Expose port
+COPY --from=builder --chown=nonroot:nonroot /app/.venv /app/.venv
+COPY --chown=nonroot:nonroot frontend/assistant.py frontend/client.py /app/
+
+USER nonroot
+WORKDIR /app
+
 EXPOSE 8501
 
-CMD ["uv", "run", "streamlit", "run", "assistant.py", "--theme.base=dark"]
+ENTRYPOINT ["/app/.venv/bin/streamlit", "run", "/app/assistant.py", "--server.address=0.0.0.0", "--server.port=8501", "--server.headless=true", "--theme.base=dark"]

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1
+# syntax=docker/dockerfile:1@sha256:ecfaec9ed6d810b56388c508f4121597bfbba70d41a6dfeee4d8cad5f295fc32
 
 FROM dhi.io/uv:0.12.5-debian13@sha256:c804efbe6ad0091c93fabafd6ee0af4273a2e3e436b8bb86c7e45c9a58fd93d3 AS uv
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ uv run streamlit run frontend/assistant.py --theme.base="dark"
 
 ## Docker Image Validation
 
-The Docker image workflow authenticates to `dhi.io` with the `DOCKER_USERNAME` and `DOCKER_PASSWORD` repository Actions secrets. Add secrets with the same names under **Settings → Secrets and variables → Dependabot** so Dependabot pull requests can run the authenticated image builds. Fork pull requests never receive these credentials; their workflow reports that image validation was not run and requires a maintainer to validate the commit from a trusted repository branch.
+The Docker image workflow authenticates to `dhi.io` with the `DOCKER_USERNAME` and `DOCKER_PASSWORD` repository Actions secrets. Add secrets with the same names under **Settings → Secrets and variables → Dependabot** so Dependabot pull requests can run the authenticated image builds. Fork pull requests never receive these credentials; their image-validation job fails before checkout and requires a maintainer to push the commit to a trusted branch in this repository.
 
 ## Qdrant API Key
 To use the Qdrant API you need to set the correct parameters in the .env file.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ This is a Rest-Backend for a Conversational Agent, that allows you to embed Docu
   - [Installation \& Development Backend](#installation--development-backend)
     - [Load Demo Data](#load-demo-data)
   - [Development Frontend](#development-frontend)
+  - [Docker Image Validation](#docker-image-validation)
   - [Qdrant API Key](#qdrant-api-key)
   - [Testing the API](#testing-the-api)
   - [Star History](#star-history)
@@ -190,6 +191,10 @@ To run the Frontend use this command in the root directory:
 uv run streamlit run frontend/assistant.py --theme.base="dark"
 ```
 
+
+## Docker Image Validation
+
+The Docker image workflow authenticates to `dhi.io` with the `DOCKER_USERNAME` and `DOCKER_PASSWORD` repository Actions secrets. Add secrets with the same names under **Settings → Secrets and variables → Dependabot** so Dependabot pull requests can run the authenticated image builds. Fork pull requests never receive these credentials; their workflow reports that image validation was not run and requires a maintainer to validate the commit from a trusted repository branch.
 
 ## Qdrant API Key
 To use the Qdrant API you need to set the correct parameters in the .env file.

--- a/tests/unit_tests/test_docker_workflow.py
+++ b/tests/unit_tests/test_docker_workflow.py
@@ -1,0 +1,56 @@
+"""Static safety checks for the Docker image workflow."""
+
+from pathlib import Path
+
+import yaml
+
+WORKFLOW_PATH = Path(__file__).parents[2] / ".github" / "workflows" / "docker.yml"
+FORK_CONDITION = "github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository"
+
+
+def load_build_job() -> dict:
+    """Load the canonical Docker validation job."""
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    assert list(workflow["jobs"]) == ["build"]
+    return workflow["jobs"]["build"]
+
+
+def test_fork_pr_fails_before_checkout() -> None:
+    """Fork PRs must fail in a no-secret step before checkout."""
+    steps = load_build_job()["steps"]
+    gate = steps[0]
+
+    assert gate["name"] == "Reject fork pull requests before validation"
+    assert gate["if"] == FORK_CONDITION
+    assert "exit 1" in gate["run"]
+    assert "uses" not in gate
+    assert "env" not in gate
+    assert "secrets." not in gate["run"]
+    assert steps[1]["uses"].startswith("actions/checkout@")
+    assert all("if" not in step for step in steps[1:])
+
+
+def test_trusted_pr_reaches_build_steps() -> None:
+    """The canonical job and trusted build path must not be skipped."""
+    job = load_build_job()
+    steps = job["steps"]
+
+    assert "if" not in job
+    for name in ("Build backend image", "Build frontend image"):
+        step = next(step for step in steps if step.get("name") == name)
+        assert "if" not in step
+
+
+def test_dependabot_reaches_credential_preflight() -> None:
+    """Same-repository bots must use the standard secret preflight."""
+    steps = load_build_job()["steps"]
+    gate = steps[0]
+    preflight = next(step for step in steps if step.get("name") == "Verify DHI credentials are configured")
+
+    assert "github.actor" not in gate["if"]
+    assert "if" not in preflight
+    assert preflight["env"] == {
+        "DOCKER_USERNAME": "${{ secrets.DOCKER_USERNAME }}",
+        "DOCKER_PASSWORD": "${{ secrets.DOCKER_PASSWORD }}",
+    }
+    assert "Dependabot secrets" in preflight["run"]

--- a/tests/unit_tests/test_docker_workflow.py
+++ b/tests/unit_tests/test_docker_workflow.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import yaml
 
 WORKFLOW_PATH = Path(__file__).parents[2] / ".github" / "workflows" / "docker.yml"
+DOCKERIGNORE_PATH = Path(__file__).parents[2] / ".dockerignore"
 FORK_CONDITION = "github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository"
 
 
@@ -54,3 +55,18 @@ def test_dependabot_reaches_credential_preflight() -> None:
         "DOCKER_PASSWORD": "${{ secrets.DOCKER_PASSWORD }}",
     }
     assert "Dependabot secrets" in preflight["run"]
+
+
+def test_checkout_does_not_persist_credentials() -> None:
+    """Do not leave checkout credentials in the Docker build workspace."""
+    steps = load_build_job()["steps"]
+    checkout = next(step for step in steps if step.get("uses", "").startswith("actions/checkout@"))
+
+    assert checkout.get("with", {}).get("persist-credentials") is False
+
+
+def test_docker_context_excludes_git_metadata() -> None:
+    """Exclude Git metadata whether .git is a directory or a worktree file."""
+    patterns = DOCKERIGNORE_PATH.read_text(encoding="utf-8").splitlines()
+
+    assert ".git" in patterns


### PR DESCRIPTION
## Summary

- migrate backend and frontend builds to matching Docker Hardened Images Python 3.13.15 Debian 13 dev/runtime stages
- copy pinned `uv`/`uvx` binaries from the Docker Hardened uv image without using it as the runtime
- pin DHI images, Dockerfile frontend, checkout action, and Qdrant smoke-test image to immutable multi-platform digests
- install the backend non-editably with the correct `agent.api:app` entrypoint
- run final images as the non-root DHI user with minimal runtime contents and explicit permissions
- add authenticated CI builds plus native-import, backend/Qdrant startup, and frontend startup smoke tests

## Images

- builder: `dhi.io/python:3.13.15-debian13-dev@sha256:2167b6b...e6af4302d7b83`
- runtime: `dhi.io/python:3.13.15-debian13@sha256:c8f52628...c4efcead9090`
- uv source: `dhi.io/uv:0.12.5-debian13@sha256:c804efbe...c9a58fd93d3`

The builder and runtime use the same Python patch version, Debian release, glibc ABI, and Python paths.

## CI trust model

- pushes and same-repository PRs perform authenticated builds and smoke tests
- Dependabot PRs use Dependabot-scoped `DOCKER_USERNAME` and `DOCKER_PASSWORD` secrets
- fork PRs fail the canonical validation job before checkout or secret access and must be validated from a trusted maintainer branch
- no `pull_request_target` workflow is used

## Verification

- full non-network suite — 59 passed, 4 deselected
- workflow trust/static tests — 3 passed
- Prek, ty, workflow schema, Markdown links, and diff checks — passed
- backend and frontend lock checks — passed
- Docker Compose configuration — passed
- pinned Qdrant pull and `/readyz` startup — passed locally
- backend startup against pinned Qdrant — passed locally
- ONNX Runtime and PDFium wheel/native-library compatibility — verified

## Required pre-merge gate

A local DHI build was not possible because this environment lacks valid `dhi.io` credentials. Both authenticated DHI builds and both final-image smoke tests in the `Docker images` workflow must pass before merge.

Configure `DOCKER_USERNAME` and `DOCKER_PASSWORD` as both Actions secrets and Dependabot secrets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added production-ready, multi-stage Docker builds for the backend and frontend.
  - Containers now run with reduced privileges and include only required production dependencies.
  - Backend and frontend services expose configured runtime entry points for deployment.

- **Tests**
  - Added automated Docker image builds, smoke tests, readiness checks, and diagnostic logging for supported changes.

- **Documentation**
  - Documented Docker image validation, required repository secrets, and fork pull request behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->